### PR TITLE
fix: Discord attachment links not working

### DIFF
--- a/common/src/main/java/com/denisnumb/discord_chat_mod/discord/DiscordEvents.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/discord/DiscordEvents.java
@@ -291,13 +291,14 @@ public class DiscordEvents extends ListenerAdapter {
     }
 
     private static @Nullable String getMessageEmbedMediaUrl(MessageEmbed embed) {
-        if (embed.getImage() != null)
+        if (embed.getImage() != null && embed.getImage().getUrl() != null)
             return embed.getImage().getUrl();
-        else if (embed.getVideoInfo() != null)
+        else if (embed.getVideoInfo() != null && embed.getVideoInfo().getUrl() != null)
             return embed.getVideoInfo().getUrl();
-        else if (embed.getThumbnail() != null)
+        else if (embed.getThumbnail() != null && embed.getThumbnail().getUrl() != null)
             return embed.getThumbnail().getUrl();
-        return null;
+        else
+            return null;
     }
 
     /**

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/discord/DiscordEvents.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/discord/DiscordEvents.java
@@ -271,11 +271,11 @@ public class DiscordEvents extends ListenerAdapter {
                 String url = embed.getUrl();
                 if (url == null)
                     return null;
-                URI uri = URI.create(url);
-                if (!DISCORD_HOSTS.contains(uri.getHost()))
-                    return null;
                 String mediaUrl = getMessageEmbedMediaUrl(embed);
                 if (mediaUrl == null)
+                    return null;
+                URI uri = URI.create(url);
+                if (!DISCORD_HOSTS.contains(uri.getHost()))
                     return null;
                 return Map.entry(url, mediaUrl);
             })

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/discord/DiscordEvents.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/discord/DiscordEvents.java
@@ -5,8 +5,12 @@ import com.denisnumb.discord_chat_mod.discord.chat_style.DiscordChatStyleProvide
 import com.denisnumb.discord_chat_mod.discord.model.DiscordGuildContext;
 import com.denisnumb.discord_chat_mod.discord.model.DiscordMentionData;
 import com.denisnumb.discord_chat_mod.markdown.MarkdownParser;
+import com.denisnumb.discord_chat_mod.markdown.MarkdownPattern;
 import com.denisnumb.discord_chat_mod.markdown.MarkdownToComponentConverter;
-import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
 import net.dv8tion.jda.api.entities.sticker.StickerItem;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
@@ -17,25 +21,42 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.awt.*;
-import java.util.List;
+import java.net.URI;
 import java.util.*;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
-import static com.denisnumb.discord_chat_mod.ColorUtils.Color.*;
+import static com.denisnumb.discord_chat_mod.ColorUtils.Color.CHAT_LINK_COLOR;
 import static com.denisnumb.discord_chat_mod.DiscordChatMod.jda;
 import static com.denisnumb.discord_chat_mod.DiscordChatMod.server;
 import static com.denisnumb.discord_chat_mod.LocaleProvider.getTranslate;
-import static com.denisnumb.discord_chat_mod.MinecraftUtils.*;
+import static com.denisnumb.discord_chat_mod.MinecraftUtils.getServerPlayerCount;
+import static com.denisnumb.discord_chat_mod.MinecraftUtils.sendMessageToAllPlayers;
 import static com.denisnumb.discord_chat_mod.ModLanguageKey.FORWARDED_GUILD_MESSAGE;
 import static com.denisnumb.discord_chat_mod.ModLanguageKey.STICKER;
 import static com.denisnumb.discord_chat_mod.chat_images.utils.ImageUtils.getInputStreamFromUrl;
-import static com.denisnumb.discord_chat_mod.chat_style.ChatStyleUtils.*;
+import static com.denisnumb.discord_chat_mod.chat_style.ChatStyleUtils.applyParametersToTemplate;
+import static com.denisnumb.discord_chat_mod.chat_style.ChatStyleUtils.parseConfigTemplateMarkdown;
 import static com.denisnumb.discord_chat_mod.chat_style.Parameters.*;
 import static com.denisnumb.discord_chat_mod.discord.DiscordUtils.*;
 import static com.denisnumb.discord_chat_mod.discord.WebhookUtils.sendWebhookWithFiles;
 
 public class DiscordEvents extends ListenerAdapter {
+
+    /**
+     * Only retrieve embed URLs for Discord attachment links.
+     * Don't retrieve embed URLs for other hosts as they may:
+     * <ul>
+     *     <li>Point media types that are incompatible with this mod, such as Tenor embed URLs pointing to video files.</li>
+     *     <li>Be "incorrect", such as an embed URL for a social media post being a link to the post's image, causing the link to the post itself being overridden.</li>
+     * </ul>
+     */
+    private static final Set<String> DISCORD_HOSTS = Set.of("cdn.discordapp.com", "media.discordapp.net");
+
     @Override
     public void onMessageReceived(MessageReceivedEvent event) {
         if (event.isWebhookMessage() || event.getAuthor().getId().equals(jda.getSelfUser().getId()))
@@ -53,8 +74,10 @@ public class DiscordEvents extends ListenerAdapter {
             System.out.printf("[Discord] <%s> %s%n", event.getAuthor().getEffectiveName(), event.getMessage().getContentDisplay());
 
         if (getServerPlayerCount(server) > 0)
-            for (Component component : prepareComponents(event.getMessage()))
-                sendMessageToAllPlayers(component);
+            prepareComponents(event.getMessage()).thenAccept(components -> {
+                for (Component component : components)
+                    sendMessageToAllPlayers(component);
+            });
 
         for (DiscordGuildContext guildContext : DiscordChannelRegistry.getAllContexts())
             if (!guildContext.defaultChannel.getId().equals(event.getMessage().getChannelId()))
@@ -119,8 +142,8 @@ public class DiscordEvents extends ListenerAdapter {
         );
     }
 
-    private static @NotNull List<Component> prepareComponents(Message message) {
-        ArrayList<Component> components = new ArrayList<>();
+    private static @NotNull CompletableFuture<List<Component>> prepareComponents(Message message) {
+        List<Component> components = new ArrayList<>();
 
         Member member = Objects.requireNonNull(message.getMember());
         String userName = member.getEffectiveName();
@@ -139,6 +162,8 @@ public class DiscordEvents extends ListenerAdapter {
                 )
         );
 
+        CompletableFuture<List<Component>> componentsFuture;
+
         if (!message.getContentRaw().isEmpty()) {
             Map<String, DiscordMentionData> mentions = new HashMap<>();
 
@@ -149,55 +174,62 @@ public class DiscordEvents extends ListenerAdapter {
             for (GuildChannel channel : message.getMentions().getChannels())
                 mentions.put(channel.getAsMention(), new DiscordMentionData(channel));
 
-            Component textPart;
-            try {
-                textPart = new MarkdownToComponentConverter(
-                        MarkdownParser.parseMarkdown(replaceDiscordEmojiMentionsToEmojiNames(message.getContentRaw())), mentions
-                ).convertMarkdownTokensToComponent();
-            } catch (Exception ignored) {
+            componentsFuture = retrieveMessageEmbedUrls(message).thenApply(embedUrls ->
+                new MarkdownToComponentConverter(
+                    MarkdownParser.parseMarkdown(
+                        replaceDiscordEmojiMentionsToEmojiNames(message.getContentRaw()),
+                        embedUrls
+                    ), mentions
+                ).convertMarkdownTokensToComponent()
+            ).exceptionally(ignored -> {
                 String content = message.getContentRaw();
                 for (var entry : mentions.entrySet())
                     content = content.replace(entry.getKey(), entry.getValue().prettyMention);
-                textPart = Component.literal(content);
-            }
-
-            addComponentsPart(components, configTemplate, guildComponent, userNameComponent, textPart);
+                return Component.literal(content);
+            }).thenApply(textPart -> {
+                addComponentsPart(components, configTemplate, guildComponent, userNameComponent, textPart);
+                return components;
+            });
+        } else {
+            componentsFuture = CompletableFuture.completedFuture(components);
         }
 
-        if (!message.getAttachments().isEmpty()) {
-            MutableComponent attachmentPart = Component.empty();
-            int index = 0;
-            List<Message.Attachment> attachments = message.getAttachments();
-            for (var file : attachments) {
-                attachmentPart.append(Component.literal(file.getFileName() + (++index < attachments.size() ? "\n" : ""))
+        return componentsFuture.thenApply(components1 -> {
+            if (!message.getAttachments().isEmpty()) {
+                MutableComponent attachmentPart = Component.empty();
+                int index = 0;
+                List<Message.Attachment> attachments = message.getAttachments();
+                for (var file : attachments) {
+                    attachmentPart.append(Component.literal(file.getFileName() + (++index < attachments.size() ? "\n" : ""))
                         .withColor(CHAT_LINK_COLOR).withStyle(style -> style.withItalic(true)
-                                .withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, file.getUrl()))
-                                .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal(file.getUrl())))
+                            .withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, file.getUrl()))
+                            .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal(file.getUrl())))
                         )
-                );
+                    );
+                }
+
+                addComponentsPart(components1, configTemplate, guildComponent, userNameComponent, attachmentPart);
             }
 
-            addComponentsPart(components, configTemplate, guildComponent, userNameComponent, attachmentPart);
-        }
-
-        if (!message.getStickers().isEmpty()) {
-            MutableComponent stickerPart = Component.empty();
-            StickerItem sticker = message.getStickers().getFirst();
-            stickerPart.append(Component.literal(String.format(getTranslate(STICKER), sticker.getName()))
+            if (!message.getStickers().isEmpty()) {
+                MutableComponent stickerPart = Component.empty();
+                StickerItem sticker = message.getStickers().getFirst();
+                stickerPart.append(Component.literal(String.format(getTranslate(STICKER), sticker.getName()))
                     .withStyle(style -> style
-                            .withItalic(true)
-                            .withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, sticker.getIconUrl()))
+                        .withItalic(true)
+                        .withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, sticker.getIconUrl()))
                     )
-            );
+                );
 
-            addComponentsPart(components, configTemplate, guildComponent, userNameComponent, stickerPart);
-        }
+                addComponentsPart(components1, configTemplate, guildComponent, userNameComponent, stickerPart);
+            }
 
-        return components;
+            return components1;
+        });
     }
 
     private static void addComponentsPart(
-            ArrayList<Component> components,
+        List<Component> components,
             String configTemplate,
             Component guildComponent,
             Component userNameComponent,
@@ -206,5 +238,66 @@ public class DiscordEvents extends ListenerAdapter {
                 parseConfigTemplateMarkdown(configTemplate),
                 Map.of(GUILD, guildComponent, MEMBER, userNameComponent, MESSAGE, messageComponent)
         ));
+    }
+
+    /**
+     * Retrieves refreshed Discord attachment links asynchronously via message embeds.
+     */
+    private static @NotNull CompletableFuture<Map<String, String>> retrieveMessageEmbedUrls(Message message) {
+        return retrieveMessageEmbedUrls(message, 3);
+    }
+
+    private static @NotNull CompletableFuture<Map<String, String>> retrieveMessageEmbedUrls(Message message, int retries) {
+        Map<String, String> embedUrls = getMessageEmbedUrls(message);
+        /*
+        Links that have been sent for the first time may not have embeds generated yet,
+        so refetch the message a few times to get the embeds.
+        Only refetch the message if it contains URLs.
+         */
+        if (retries <= 0 || (embedUrls.isEmpty() && hasUrls(message.getContentRaw()))) {
+            return message.getChannel()
+                .retrieveMessageById(message.getId())
+                .submit()
+                .thenCompose(refetchedMessage -> retrieveMessageEmbedUrls(refetchedMessage, retries - 1));
+        } else {
+            return CompletableFuture.completedFuture(embedUrls);
+        }
+    }
+
+    private static @NotNull Map<String, String> getMessageEmbedUrls(Message message) {
+        return message.getEmbeds()
+            .stream()
+            .map((embed) -> {
+                String url = embed.getUrl();
+                if (url == null)
+                    return null;
+                URI uri = URI.create(url);
+                if (!DISCORD_HOSTS.contains(uri.getHost()))
+                    return null;
+                String mediaUrl = getMessageEmbedMediaUrl(embed);
+                if (mediaUrl == null)
+                    return null;
+                return Map.entry(url, mediaUrl);
+            })
+            .filter(Objects::nonNull)
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private static @Nullable String getMessageEmbedMediaUrl(MessageEmbed embed) {
+        String mediaUrl = null;
+        if (embed.getImage() != null)
+            mediaUrl = embed.getImage().getUrl();
+        else if (embed.getVideoInfo() != null)
+            mediaUrl = embed.getVideoInfo().getUrl();
+        else if (embed.getThumbnail() != null)
+            mediaUrl = embed.getThumbnail().getUrl();
+        return mediaUrl;
+    }
+
+    private static boolean hasUrls(String text) {
+        return MarkdownPattern.URL.matcher(text).results().anyMatch(matchResult -> {
+            URI uri = URI.create(matchResult.group());
+            return DISCORD_HOSTS.contains(uri.getHost());
+        });
     }
 }

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/discord/DiscordEvents.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/discord/DiscordEvents.java
@@ -291,14 +291,13 @@ public class DiscordEvents extends ListenerAdapter {
     }
 
     private static @Nullable String getMessageEmbedMediaUrl(MessageEmbed embed) {
-        String mediaUrl = null;
         if (embed.getImage() != null)
-            mediaUrl = embed.getImage().getUrl();
+            return embed.getImage().getUrl();
         else if (embed.getVideoInfo() != null)
-            mediaUrl = embed.getVideoInfo().getUrl();
+            return embed.getVideoInfo().getUrl();
         else if (embed.getThumbnail() != null)
-            mediaUrl = embed.getThumbnail().getUrl();
-        return mediaUrl;
+            return embed.getThumbnail().getUrl();
+        return null;
     }
 
     /**

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/discord/DiscordEvents.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/discord/DiscordEvents.java
@@ -242,6 +242,10 @@ public class DiscordEvents extends ListenerAdapter {
 
     /**
      * Retrieves refreshed Discord attachment links asynchronously via message embeds.
+docs     *
+     * @param message The message to retrieve the refreshed URLs from.
+     *
+     * @return A future that resolves to a mapping of URLs in the message text to the corresponding refreshed URL.
      */
     private static @NotNull CompletableFuture<Map<String, String>> retrieveMessageEmbedUrls(Message message) {
         return retrieveMessageEmbedUrls(message, 3);
@@ -297,6 +301,9 @@ public class DiscordEvents extends ListenerAdapter {
         return mediaUrl;
     }
 
+    /**
+     * Checks if the {@code text} contains any Discord CDN URLs.
+     */
     private static boolean hasUrls(String text) {
         return MarkdownPattern.URL.matcher(text).results().anyMatch(matchResult -> {
             URI uri = URI.create(matchResult.group());

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/discord/DiscordEvents.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/discord/DiscordEvents.java
@@ -254,7 +254,7 @@ public class DiscordEvents extends ListenerAdapter {
         so refetch the message a few times to get the embeds.
         Only refetch the message if it contains URLs.
          */
-        if (retries <= 0 || (embedUrls.isEmpty() && hasUrls(message.getContentRaw()))) {
+        if (retries > 0 && embedUrls.isEmpty() && hasUrls(message.getContentRaw())) {
             return message.getChannel()
                 .retrieveMessageById(message.getId())
                 .submit()

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/discord/DiscordEvents.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/discord/DiscordEvents.java
@@ -249,20 +249,22 @@ public class DiscordEvents extends ListenerAdapter {
 
     private static @NotNull CompletableFuture<Map<String, String>> retrieveMessageEmbedUrls(Message message, int retries) {
         Map<String, String> embedUrls = getMessageEmbedUrls(message);
-        /*
-         * Links that have been sent for the first time may not have embeds generated yet,
-         * so refetch the message a few times to get the embeds.
-         * Only refetch the message if it contains URLs.
-         */
-        if (retries > 0 && embedUrls.isEmpty() && hasUrls(message.getContentRaw())) {
-            return message.getChannel()
-                .retrieveMessageById(message.getId())
-                .submit()
-                .exceptionally(ignored -> message)
-                .thenCompose(refetchedMessage -> retrieveMessageEmbedUrls(refetchedMessage, retries - 1));
-        } else {
-            return CompletableFuture.completedFuture(embedUrls);
+        try {
+            /*
+             * Links that have been sent for the first time may not have embeds generated yet,
+             * so refetch the message a few times to get the embeds.
+             * Only refetch the message if it contains URLs.
+             */
+            if (retries > 0 && embedUrls.isEmpty() && hasUrls(message.getContentRaw())) {
+                return message.getChannel()
+                    .retrieveMessageById(message.getId())
+                    .submit()
+                    .exceptionally(ignored -> message)
+                    .thenCompose(refetchedMessage -> retrieveMessageEmbedUrls(refetchedMessage, retries - 1));
+            }
+        } catch (Exception ignored) {
         }
+        return CompletableFuture.completedFuture(embedUrls);
     }
 
     private static @NotNull Map<String, String> getMessageEmbedUrls(Message message) {

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/discord/DiscordEvents.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/discord/DiscordEvents.java
@@ -242,7 +242,7 @@ public class DiscordEvents extends ListenerAdapter {
 
     /**
      * Retrieves refreshed Discord attachment links asynchronously via message embeds.
-docs     *
+     *
      * @param message The message to retrieve the refreshed URLs from.
      *
      * @return A future that resolves to a mapping of URLs in the message text to the corresponding refreshed URL.

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/discord/DiscordEvents.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/discord/DiscordEvents.java
@@ -250,14 +250,15 @@ public class DiscordEvents extends ListenerAdapter {
     private static @NotNull CompletableFuture<Map<String, String>> retrieveMessageEmbedUrls(Message message, int retries) {
         Map<String, String> embedUrls = getMessageEmbedUrls(message);
         /*
-        Links that have been sent for the first time may not have embeds generated yet,
-        so refetch the message a few times to get the embeds.
-        Only refetch the message if it contains URLs.
+         * Links that have been sent for the first time may not have embeds generated yet,
+         * so refetch the message a few times to get the embeds.
+         * Only refetch the message if it contains URLs.
          */
         if (retries > 0 && embedUrls.isEmpty() && hasUrls(message.getContentRaw())) {
             return message.getChannel()
                 .retrieveMessageById(message.getId())
                 .submit()
+                .exceptionally(ignored -> message)
                 .thenCompose(refetchedMessage -> retrieveMessageEmbedUrls(refetchedMessage, retries - 1));
         } else {
             return CompletableFuture.completedFuture(embedUrls);

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/markdown/MarkdownParser.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/markdown/MarkdownParser.java
@@ -29,6 +29,10 @@ public abstract class MarkdownParser {
     }
 
     public static List<MarkdownToken> parseMarkdown(String rawText){
+        return parseMarkdown(rawText, Map.of());
+    }
+
+    public static List<MarkdownToken> parseMarkdown(String rawText, Map<String, String> urlMapping) {
         ArrayList<MarkdownToken> tokens = new ArrayList<>();
         int currentPos = 0;
 
@@ -70,11 +74,12 @@ public abstract class MarkdownParser {
             switch (style){
                 case MarkdownStyle.URL -> {
                     token = new MarkdownToken(matchedText);
-                    token.url = matchedText;
+                    token.url = urlMapping.getOrDefault(matchedText, matchedText);
                 }
                 case MarkdownStyle.LINK -> {
                     token = new MarkdownToken(matchedText, innerText);
-                    token.url = matcher.group(2);
+                    String url = matcher.group(2);
+                    token.url = urlMapping.getOrDefault(url, url);
                 }
                 case MarkdownStyle.DISCORD_MENTION -> {
                     token = new MarkdownToken(matchedText);


### PR DESCRIPTION
Fix Discord attachment links not displaying images in-game by retrieving the refreshed attachment link via the message embeds.

Fixes #23