### PR TITLE
feat: make bot presence status configurable 1.20.1

### DIFF
--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigComments.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigComments.java
@@ -52,6 +52,13 @@ public class ConfigComments {
              Used to generate timestamps for message style configurations.\
             """;
 
+    public static final String ENABLE_BOT_PRESENCE_STATUS_COMMENT
+            = """
+             If true, the bot's Discord presence (custom status) will display the current online player count, e.g. "Online: 3/20".\
+
+             Set to false to disable the presence status entirely (the bot will appear without a custom status).\
+            """;
+
     // =================================================================================================================
     //                                          DISCORD GUILD CONFIG COMMENTS
     // =================================================================================================================

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigDefaults.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigDefaults.java
@@ -9,6 +9,7 @@ public class ConfigDefaults {
     public static final String DISCORD_ERRORS_CHAT_PLAYER_SELECTOR_DEFAULT = "@a";
     public static final String MOD_LOCALE_DEFAULT = "en_us";
     public static final int UTC_OFFSET_HOURS_DEFAULT = 0;
+    public static final boolean ENABLE_BOT_PRESENCE_STATUS_DEFAULT = true;
 
     // =================================================================================================================
     //                                              WEBHOOK MODE DEFAULTS

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigProviderImpl.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigProviderImpl.java
@@ -52,6 +52,11 @@ public class ConfigProviderImpl implements IConfigProvider {
     }
 
     @Override
+    public boolean isBotPresenceStatusEnabled() {
+        return CommonConfig.enableBotPresenceStatus;
+    }
+
+    @Override
     public boolean isWebhookModeEnabled() {
         return WebhookModeConfig.enableWebhookMode;
     }

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/IConfigProvider.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/IConfigProvider.java
@@ -15,6 +15,7 @@ public interface IConfigProvider {
     String discordErrorsChatPlayerSelector();
     String modLocale();
     int utcOffsetHours();
+    boolean isBotPresenceStatusEnabled();
 
     boolean isWebhookModeEnabled();
     String webhookServerName();

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/configs/CommonConfig.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/configs/CommonConfig.java
@@ -14,6 +14,7 @@ public class CommonConfig {
     public static String discordErrorsChatPlayerSelector;
     public static String modLocale;
     public static int utcOffsetHours;
+    public static boolean enableBotPresenceStatus;
 
     public static void loadCommonConfig(CommentedConfig commonConfig){
         discordBotToken = commonConfig.getOrElse("discordBotToken", DISCORD_BOT_TOKEN_DEFAULT);
@@ -51,5 +52,9 @@ public class CommonConfig {
         if (utcOffsetHours > 14) utcOffsetHours = 14;
         commonConfig.set("utcOffsetHours", utcOffsetHours);
         commonConfig.setComment("utcOffsetHours", UTC_OFFSET_HOURS_COMMENT + String.format("\n Default: %d\n Range: -12 ~ 14", UTC_OFFSET_HOURS_DEFAULT));
+
+        enableBotPresenceStatus = commonConfig.getOrElse("enableBotPresenceStatus", ENABLE_BOT_PRESENCE_STATUS_DEFAULT);
+        commonConfig.set("enableBotPresenceStatus", enableBotPresenceStatus);
+        commonConfig.setComment("enableBotPresenceStatus", ENABLE_BOT_PRESENCE_STATUS_COMMENT);
     }
 }

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/discord/ServerStatusController.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/discord/ServerStatusController.java
@@ -129,7 +129,11 @@ public class ServerStatusController {
             });
         }
 
-        jda.getPresence().setActivity(Activity.customStatus(getOnlineCountString()));
+        if (ConfigProvider.getConfig().isBotPresenceStatusEnabled()) {
+            jda.getPresence().setActivity(Activity.customStatus(getOnlineCountString()));
+        } else {
+            jda.getPresence().setActivity(null);
+        }
     }
 
     private static String getOnlineCountString() {


### PR DESCRIPTION
Adds an `enableBotPresenceStatus` option (default `true`) to control whether the bot's custom status shows the online player count. When set to `false`, the bot appears with no custom status, and an existing one is cleared on the next update. The pinned status message is unaffected.

Tested on two Minecraft servers connected to the same Discord guild.

Port of #86 to the `1.20.1` branch.