### PR TITLE
fix: prevent server crash loop on Discord API outage 1.21.9

### DIFF
--- a/common/src/main/java/com/denisnumb/discord_chat_mod/DiscordChatMod.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/DiscordChatMod.java
@@ -51,8 +51,11 @@ public final class DiscordChatMod {
 
     public static void onServerStarting(MinecraftServer minecraftServer) {
         server = minecraftServer;
-        if (server.isPublished())
-            initJDA();
+        if (server.isPublished()) {
+            Thread t = new Thread(DiscordChatMod::initJDA);
+            t.setDaemon(true);
+            t.start();
+        }
 
         CustomChatTypeRegistry.registerChatTypes(server.registryAccess().lookupOrThrow(Registries.CHAT_TYPE));
     }


### PR DESCRIPTION
Fixes #92.

Wraps `initJDA()` in a daemon thread for dedicated servers, mirroring the pattern already used in `onIntegratedServerStarted()`. Without this, a Discord API outage during server startup blocks the server-starting tick, triggers a `ServerHangWatchdog` crash, and puts the server into a restart loop. JDA's gateway retry reconnects automatically once Discord recovers.

Verified normal startup with reachable Discord (server reaches Done, bot connects, chat bridge works), and a simulated outage by routing `discord.com`, `gateway.discord.gg`, and `discordapp.com` to an unreachable IP (`192.0.2.1`) via the hosts file (server reaches Done within normal time, no watchdog crash, players can join, bot reconnects on its own once DNS is restored without a server restart).

Port of #93 to the 1.21.9 branch.