### PR TITLE
feat: log player commands to discord 1.21.1

### DIFF
--- a/common/src/main/java/com/denisnumb/discord_chat_mod/MinecraftEvents.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/MinecraftEvents.java
@@ -129,6 +129,37 @@ public class MinecraftEvents {
         return Optional.empty();
     }
 
+    public static void handleCommandExecution(CommandSourceStack source, String command) {
+        IConfigProvider config = ConfigProvider.getConfig();
+        if (!config.isCommandLogEnabled())
+            return;
+
+        Player player = source.getPlayer();
+        if (player == null)
+            return;
+
+        if (!source.hasPermission(config.commandLogMinPermissionLevel()))
+            return;
+
+        String trimmed = command.startsWith("/") ? command.substring(1) : command;
+        int spaceIdx = trimmed.indexOf(' ');
+        String rootCommand = (spaceIdx == -1 ? trimmed : trimmed.substring(0, spaceIdx))
+                .toLowerCase(java.util.Locale.ROOT);
+        if (rootCommand.isEmpty() || config.commandLogIgnoredCommands().contains(rootCommand))
+            return;
+
+        String displayCommand = "/" + trimmed;
+
+        handleDiscord(() -> {
+            Map<String, String> parameters = mergeMaps(
+                    Map.of(COMMAND, displayCommand),
+                    buildPlayerParameters(player)
+            );
+            getDiscordMessageComponents(MessageType.COMMAND_LOG, parameters)
+                    .ifPresent(components -> sendMessageFromServer(ChannelCategory.COMMAND_LOG, getAllContexts(), components));
+        });
+    }
+
     public static Optional<Component> handleJoinLeave(Player player, boolean isJoin) {
         handleDiscord(() -> {
             MessageType messageType = isJoin ? MessageType.JOIN : MessageType.LEFT;

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/chat_style/Parameters.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/chat_style/Parameters.java
@@ -40,4 +40,5 @@ public class Parameters {
     public static final String DATETIME = "{datetime}";
     public static final String GUILD = "{guild}";
     public static final String COUNTER = "{counter}";
+    public static final String COMMAND = "{command}";
 }

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigComments.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigComments.java
@@ -59,6 +59,19 @@ public class ConfigComments {
              Set to false to disable the presence status entirely (the bot will appear without a custom status).\
             """;
 
+    public static final String COMMAND_LOG_ENABLED_COMMENT
+            = " Enable logging of commands executed by players to a Discord channel." +
+            "\n Only commands from players whose permission level is at least commandLogMinPermissionLevel are logged.";
+
+    public static final String COMMAND_LOG_MIN_PERMISSION_LEVEL_COMMENT
+            = " Minimum permission level required for a player's commands to be logged (0-4)." +
+            "\n 0 = all players, 2 = operators (default), 3 = admins, 4 = owners.";
+
+    public static final String COMMAND_LOG_IGNORED_COMMANDS_COMMENT
+            = " Comma-separated list of root command names to skip (without the leading /)." +
+            "\n Matching is case-insensitive. Example: \"msg, tell, w, help, list\"" +
+            "\n Leave blank to log every command that passes the permission level filter.";
+
     // =================================================================================================================
     //                                          DISCORD GUILD CONFIG COMMENTS
     // =================================================================================================================
@@ -172,6 +185,10 @@ public class ConfigComments {
     public static final String ME_CHANNEL_ID_COMMENT
             = " Overrides the default channel for messages sent using /me command. If empty, uses defaultChannelId." +
             "\n Specify \"-1\" to disable sending messages send using /me command to Discord";
+
+    public static final String COMMAND_LOG_CHANNEL_ID_COMMENT
+            = " Overrides the default channel for logged player commands. If empty, uses defaultChannelId." +
+            "\n Specify \"-1\" to disable sending command log messages to Discord";
 
     // =================================================================================================================
     //                                      MINECRAFT CHAT CUSTOMIZATION COMMENTS
@@ -432,8 +449,15 @@ public class ConfigComments {
     public static final String DISCORD_TELLRAW_COMMAND_STYLE_COMMENT
             = """
              Chat message from send using /tellraw @a command\
-            
+
              Parameters: {message}\
+            """;
+
+    public static final String DISCORD_COMMAND_LOG_STYLE_COMMENT
+            = """
+             Command executed by a player above the configured permission level\
+
+             Parameters: {player}, {command}\
             """;
 
     public static final String DISCORD_SCREENSHOT_MESSAGE_STYLE_COMMENT

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigDefaults.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigDefaults.java
@@ -11,6 +11,10 @@ public class ConfigDefaults {
     public static final int UTC_OFFSET_HOURS_DEFAULT = 0;
     public static final boolean ENABLE_BOT_PRESENCE_STATUS_DEFAULT = true;
 
+    public static final boolean COMMAND_LOG_ENABLED_DEFAULT = false;
+    public static final int COMMAND_LOG_MIN_PERMISSION_LEVEL_DEFAULT = 2;
+    public static final String COMMAND_LOG_IGNORED_COMMANDS_DEFAULT = "";
+
     // =================================================================================================================
     //                                              WEBHOOK MODE DEFAULTS
     // =================================================================================================================
@@ -204,6 +208,21 @@ public class ConfigDefaults {
             """
             {
                 "content": "{message}"
+            }
+            """;
+
+    public static final String DISCORD_COMMAND_LOG_STYLE_DEFAULT =
+            """
+            {
+                "embed": {
+                    "description": "`{command}`",
+                    "color": "#F1C40F",
+                    "author": {
+                        "name": "{player}",
+                        "icon_url": "{player_avatar_url}"
+                    },
+                    "timestamp": "{datetime}"
+                }
             }
             """;
 

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigProviderImpl.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigProviderImpl.java
@@ -4,6 +4,7 @@ import com.denisnumb.discord_chat_mod.config.configs.*;
 import com.denisnumb.discord_chat_mod.config.configs.DiscordGuildsConfig.DiscordGuildConfig;
 
 import java.util.List;
+import java.util.Set;
 
 public class ConfigProviderImpl implements IConfigProvider {
     @Override
@@ -54,6 +55,21 @@ public class ConfigProviderImpl implements IConfigProvider {
     @Override
     public boolean isBotPresenceStatusEnabled() {
         return CommonConfig.enableBotPresenceStatus;
+    }
+
+    @Override
+    public boolean isCommandLogEnabled() {
+        return CommonConfig.commandLogEnabled;
+    }
+
+    @Override
+    public int commandLogMinPermissionLevel() {
+        return CommonConfig.commandLogMinPermissionLevel;
+    }
+
+    @Override
+    public Set<String> commandLogIgnoredCommands() {
+        return CommonConfig.commandLogIgnoredCommands;
     }
 
     @Override
@@ -274,6 +290,11 @@ public class ConfigProviderImpl implements IConfigProvider {
     @Override
     public String discordTellrawCommandStyle() {
         return DiscordChatStyleConfig.discordTellrawCommandStyle;
+    }
+
+    @Override
+    public String discordCommandLogStyle() {
+        return DiscordChatStyleConfig.discordCommandLogStyle;
     }
 
     @Override

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/IConfigProvider.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/IConfigProvider.java
@@ -3,6 +3,7 @@ package com.denisnumb.discord_chat_mod.config;
 import com.denisnumb.discord_chat_mod.config.configs.DiscordGuildsConfig;
 
 import java.util.List;
+import java.util.Set;
 
 public interface IConfigProvider {
     List<DiscordGuildsConfig.DiscordGuildConfig> discordGuildConfigs();
@@ -16,6 +17,10 @@ public interface IConfigProvider {
     String modLocale();
     int utcOffsetHours();
     boolean isBotPresenceStatusEnabled();
+
+    boolean isCommandLogEnabled();
+    int commandLogMinPermissionLevel();
+    Set<String> commandLogIgnoredCommands();
 
     boolean isWebhookModeEnabled();
     String webhookServerName();
@@ -64,6 +69,7 @@ public interface IConfigProvider {
     String discordMeCommandStyle();
     String discordMeCommandWebhookStyle();
     String discordTellrawCommandStyle();
+    String discordCommandLogStyle();
     String discordScreenshotMessageStyle();
     String discordScreenshotMessageWebhookStyle();
     String discordServerStartedMessageStyle();

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/configs/CommonConfig.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/configs/CommonConfig.java
@@ -2,6 +2,11 @@ package com.denisnumb.discord_chat_mod.config.configs;
 
 import com.electronwill.nightconfig.core.CommentedConfig;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import static com.denisnumb.discord_chat_mod.config.ConfigComments.*;
 import static com.denisnumb.discord_chat_mod.config.ConfigComments.DISCORD_ERRORS_CHAT_PLAYER_SELECTOR_COMMENT;
 import static com.denisnumb.discord_chat_mod.config.ConfigComments.ENABLE_PINNED_STATUS_MESSAGE_COMMENT;
@@ -23,6 +28,9 @@ public class CommonConfig {
     public static String modLocale;
     public static int utcOffsetHours;
     public static boolean enableBotPresenceStatus;
+    public static boolean commandLogEnabled;
+    public static int commandLogMinPermissionLevel;
+    public static Set<String> commandLogIgnoredCommands = Collections.emptySet();
 
     public static void loadCommonConfig(CommentedConfig commonConfig){
         discordBotToken = commonConfig.getOrElse("discordBotToken", DISCORD_BOT_TOKEN_DEFAULT);
@@ -64,5 +72,24 @@ public class CommonConfig {
         enableBotPresenceStatus = commonConfig.getOrElse("enableBotPresenceStatus", ENABLE_BOT_PRESENCE_STATUS_DEFAULT);
         commonConfig.set("enableBotPresenceStatus", enableBotPresenceStatus);
         commonConfig.setComment("enableBotPresenceStatus", ENABLE_BOT_PRESENCE_STATUS_COMMENT);
+
+        commandLogEnabled = commonConfig.getOrElse("commandLogEnabled", COMMAND_LOG_ENABLED_DEFAULT);
+        commonConfig.set("commandLogEnabled", commandLogEnabled);
+        commonConfig.setComment("commandLogEnabled", COMMAND_LOG_ENABLED_COMMENT);
+
+        commandLogMinPermissionLevel = commonConfig.getOrElse("commandLogMinPermissionLevel", COMMAND_LOG_MIN_PERMISSION_LEVEL_DEFAULT);
+        if (commandLogMinPermissionLevel < 0) commandLogMinPermissionLevel = 0;
+        if (commandLogMinPermissionLevel > 4) commandLogMinPermissionLevel = 4;
+        commonConfig.set("commandLogMinPermissionLevel", commandLogMinPermissionLevel);
+        commonConfig.setComment("commandLogMinPermissionLevel", COMMAND_LOG_MIN_PERMISSION_LEVEL_COMMENT);
+
+        String ignoredCommandsRaw = commonConfig.getOrElse("commandLogIgnoredCommands", COMMAND_LOG_IGNORED_COMMANDS_DEFAULT);
+        commandLogIgnoredCommands = Arrays.stream(ignoredCommandsRaw.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(s -> s.toLowerCase(java.util.Locale.ROOT))
+                .collect(Collectors.toUnmodifiableSet());
+        commonConfig.set("commandLogIgnoredCommands", ignoredCommandsRaw);
+        commonConfig.setComment("commandLogIgnoredCommands", COMMAND_LOG_IGNORED_COMMANDS_COMMENT);
     }
 }

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/configs/DiscordChatStyleConfig.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/configs/DiscordChatStyleConfig.java
@@ -30,6 +30,7 @@ public class DiscordChatStyleConfig {
     public static String discordMeCommandStyle;
     public static String discordMeCommandWebhookStyle;
     public static String discordTellrawCommandStyle;
+    public static String discordCommandLogStyle;
     public static String discordScreenshotMessageStyle;
     public static String discordScreenshotMessageWebhookStyle;
     public static String discordServerStartedMessageStyle;
@@ -118,6 +119,11 @@ public class DiscordChatStyleConfig {
         discordChatStyle.set("discordTellrawCommandStyle", discordTellrawCommandStyle.replace("\r", ""));
         discordChatStyle.setComment("discordTellrawCommandStyle", DISCORD_TELLRAW_COMMAND_STYLE_COMMENT);
         discordTellrawCommandStyle = validateJsonValue(discordTellrawCommandStyle, DISCORD_TELLRAW_COMMAND_STYLE_DEFAULT);
+
+        discordCommandLogStyle = existedDiscordChatStyle.getOrElse("discordCommandLogStyle", DISCORD_COMMAND_LOG_STYLE_DEFAULT);
+        discordChatStyle.set("discordCommandLogStyle", discordCommandLogStyle.replace("\r", ""));
+        discordChatStyle.setComment("discordCommandLogStyle", DISCORD_COMMAND_LOG_STYLE_COMMENT);
+        discordCommandLogStyle = validateJsonValue(discordCommandLogStyle, DISCORD_COMMAND_LOG_STYLE_DEFAULT);
 
         discordScreenshotMessageStyle = existedDiscordChatStyle.getOrElse("discordScreenshotMessageStyle", DISCORD_SCREENSHOT_MESSAGE_STYLE_DEFAULT);
         discordChatStyle.set("discordScreenshotMessageStyle", discordScreenshotMessageStyle.replace("\r", ""));

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/discord/chat_style/DiscordChatStyleProvider.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/discord/chat_style/DiscordChatStyleProvider.java
@@ -185,6 +185,7 @@ public class DiscordChatStyleProvider {
                 case ME_COMMAND -> parseDiscordConfigTemplate(config.discordMeCommandStyle(), parameterMap);
                 case ME_COMMAND_WEBHOOK -> parseDiscordConfigTemplate(config.discordMeCommandWebhookStyle(), parameterMap);
                 case TELLRAW_COMMAND -> parseDiscordConfigTemplate(config.discordTellrawCommandStyle(), parameterMap);
+                case COMMAND_LOG -> parseDiscordConfigTemplate(config.discordCommandLogStyle(), parameterMap);
             };
 
             return Optional.of(result);

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/discord/chat_style/MessageType.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/discord/chat_style/MessageType.java
@@ -21,5 +21,6 @@ public enum MessageType {
     SAY_COMMAND,
     ME_COMMAND,
     ME_COMMAND_WEBHOOK,
-    TELLRAW_COMMAND
+    TELLRAW_COMMAND,
+    COMMAND_LOG
 }

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/discord/model/ChannelCategory.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/discord/model/ChannelCategory.java
@@ -14,7 +14,8 @@ public enum ChannelCategory {
     SCREENSHOTS("screenshotsChannelId"),
     TELLRAW_COMMAND("tellrawChannelId"),
     SAY_COMMAND("sayChannelId"),
-    ME_COMMAND("meChannelId");
+    ME_COMMAND("meChannelId"),
+    COMMAND_LOG("commandLogChannelId");
 
     private final String configName;
 
@@ -38,6 +39,7 @@ public enum ChannelCategory {
             case TELLRAW_COMMAND -> TELLRAW_CHANNEL_ID_COMMENT;
             case SAY_COMMAND -> SAY_CHANNEL_ID_COMMENT;
             case ME_COMMAND -> ME_CHANNEL_ID_COMMENT;
+            case COMMAND_LOG -> COMMAND_LOG_CHANNEL_ID_COMMENT;
         };
     }
 

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/mixin/PerformCommandMixin.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/mixin/PerformCommandMixin.java
@@ -1,0 +1,21 @@
+package com.denisnumb.discord_chat_mod.mixin;
+
+import com.denisnumb.discord_chat_mod.MinecraftEvents;
+import com.mojang.brigadier.ParseResults;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(Commands.class)
+public abstract class PerformCommandMixin {
+    @Inject(
+            method = "performCommand",
+            at = @At("HEAD")
+    )
+    private void discordChatMod$logCommandExecution(ParseResults<CommandSourceStack> parseResults, String command, CallbackInfoReturnable<Integer> cir) {
+        MinecraftEvents.handleCommandExecution(parseResults.getContext().getSource(), command);
+    }
+}

--- a/fabric/src/main/resources/discord_chat_mod.mixins.json
+++ b/fabric/src/main/resources/discord_chat_mod.mixins.json
@@ -5,6 +5,7 @@
   "refmap": "discord_chat_mod-common-common-refmap.json",
   "mixins": [
     "CommandsMixin",
+    "PerformCommandMixin",
     "chat_style.ServerGamePacketListenerImplMixin",
     "chat_style.CombatTrackerAccessorMixin",
     "chat_style.TamableAnimalMixin",

--- a/neoforge/src/main/resources/discord_chat_mod.mixins.json
+++ b/neoforge/src/main/resources/discord_chat_mod.mixins.json
@@ -3,6 +3,7 @@
   "package": "com.denisnumb.discord_chat_mod.mixin",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
+    "PerformCommandMixin",
     "chat_style.ServerGamePacketListenerImplMixin",
     "chat_style.CombatTrackerAccessorMixin",
     "chat_style.TamableAnimalMixin",


### PR DESCRIPTION
Fixes #99.

Adds an opt-in audit trail of player-issued commands to Discord. Disabled by default; when enabled, only commands from players at or above the configured permission level are logged.

New config knobs:

- `commandLogEnabled` (default: off)
- `commandLogMinPermissionLevel` (default: 2, clamped 0-4)
- `commandLogIgnoredCommands` (comma-separated root command names)
- `commandLogChannelId` per-guild override, falls back to `defaultChannelId`
- `discordCommandLogStyle` embed template with `{player}` and `{command}`

The hook is a common Mixin into `Commands.performCommand`, so NeoForge and Fabric share one code path. Non-player sources (console, command blocks, `/execute as` entity chains) are skipped so each player-issued command produces a single audit entry.

Tested with `./gradlew check` on common, neoforge, and fabric. I have been running this on my own NeoForge servers for the past 1-2 months without issue. Manual in-game verification on Fabric and Forge is still pending.

If satisfied, I will port it to the other version branches (1.20.1, 1.21.8, 1.21.9, 1.21.10, 1.21.11) in follow-up PRs.