### PR TITLE
fix: correct PerformCommandMixin callback type 1.21.1

### DIFF
--- a/common/src/main/java/com/denisnumb/discord_chat_mod/mixin/PerformCommandMixin.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/mixin/PerformCommandMixin.java
@@ -7,7 +7,7 @@ import net.minecraft.commands.Commands;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Commands.class)
 public abstract class PerformCommandMixin {
@@ -15,7 +15,7 @@ public abstract class PerformCommandMixin {
             method = "performCommand",
             at = @At("HEAD")
     )
-    private void discordChatMod$logCommandExecution(ParseResults<CommandSourceStack> parseResults, String command, CallbackInfoReturnable<Integer> cir) {
+    private void discordChatMod$logCommandExecution(ParseResults<CommandSourceStack> parseResults, String command, CallbackInfo ci) {
         MinecraftEvents.handleCommandExecution(parseResults.getContext().getSource(), command);
     }
 }


### PR DESCRIPTION
Follow-up fix to #99 and PRs #101-#106. Sorry I didn't catch this initially.

PerformCommandMixin declared its callback as CallbackInfoReturnable<Integer>, which matches Commands.performCommand only on 1.20.1. From 1.21.1 onward the method returns void, so Mixin's load-time descriptor check rejects the injection with InvalidInjectionException and the mod fails to load on every 1.21.x server. Switched the callback to CallbackInfo and updated the import.

Tested on 1.21.1-11: server loads cleanly, command logging fires for ops as configured. 1.20.1 (PR #102) is unaffected.

Port of #107 to the 1.21.1 branch.