### PR TITLE
fix: pin UTF-8 charset for discord mentions transceiver 1.21.1

### DIFF
--- a/common/src/main/java/com/denisnumb/discord_chat_mod/network/mentions/DiscordMentionsTransceiver.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/network/mentions/DiscordMentionsTransceiver.java
@@ -12,6 +12,7 @@ import net.minecraft.server.level.ServerPlayer;
 import org.slf4j.Logger;
 
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -42,7 +43,7 @@ public class DiscordMentionsTransceiver {
     public static void sendDiscordMemberDataToPlayer(ServerPlayer player) {
         long sendTime = System.currentTimeMillis();
 
-        byte[] data = gson.toJson(ChannelMembersProvider.getMemberData(ChannelCategory.PLAYER_CHAT), gsonType).getBytes();
+        byte[] data = gson.toJson(ChannelMembersProvider.getMemberData(ChannelCategory.PLAYER_CHAT), gsonType).getBytes(StandardCharsets.UTF_8);
         BigPacketsTransceiver.send(data, (partIndex, totalParts, part) ->
                 PlatformPacketDistributor.sendToPlayer(player, new DiscordMentionsPartPacket(sendTime, partIndex, totalParts, part))
         );
@@ -55,6 +56,6 @@ public class DiscordMentionsTransceiver {
                 packet.partIndex(),
                 packet.totalParts(),
                 packet.data()
-        ).ifPresent(bytes -> ChannelMembersProvider.CLIENT_MEMBER_CACHE = gson.fromJson(new String(bytes), gsonType));
+        ).ifPresent(bytes -> ChannelMembersProvider.CLIENT_MEMBER_CACHE = gson.fromJson(new String(bytes, StandardCharsets.UTF_8), gsonType));
     }
 }


### PR DESCRIPTION
Fixes #74.

DiscordMentionsTransceiver encoded the JSON member-data payload with String.getBytes() (no-arg) and decoded it with new String(byte[]) (no-arg), both of which use the platform default charset. On Java 17 (used by 1.20.1 servers/clients) this is windows-1252 on Windows, which cannot represent CJK characters, so usernames like テスト get destroyed in the encode step and arrive at the @-autocomplete client cache as ??????. JEP 400 hides this from Java 18+ users by default, but the bug still triggers anywhere file.encoding is overridden or the locale is non-UTF-8. The /mention slash command path is unaffected because it goes through Brigadier's vanilla protocol which is UTF-8 throughout.

Pin both encode and decode to StandardCharsets.UTF_8 so the round-trip is correct regardless of platform default.

Verified end-to-end on a 1.20.1 fabric dev server with -Dfile.encoding=Cp1252 and a CJK-named guild member: before the fix, @-autocomplete shows @??????; after the fix, the CJK characters render correctly. Slash command /mention continues to work as before.

Port of #112 to the 1.21.1 branch.