### PR TITLE
fix: prevent client crash on oversized chat messages 1.21.9

### DIFF
--- a/common/src/main/java/com/denisnumb/discord_chat_mod/mixin/ChatComponentMixin.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/mixin/ChatComponentMixin.java
@@ -145,7 +145,7 @@ public abstract class ChatComponentMixin {
             int parentAddedTime = allMessages.getLast().addedTime();
 
             do allMessages.removeLast();
-            while (allMessages.getLast().addedTime() == parentAddedTime);
+            while (!allMessages.isEmpty() && allMessages.getLast().addedTime() == parentAddedTime);
         }
     }
 
@@ -162,7 +162,7 @@ public abstract class ChatComponentMixin {
             int parentAddedTime = trimmedMessages.getLast().addedTime();
 
             do trimmedMessages.removeLast();
-            while (trimmedMessages.getLast().addedTime() == parentAddedTime);
+            while (!trimmedMessages.isEmpty() && trimmedMessages.getLast().addedTime() == parentAddedTime);
         }
     }
 


### PR DESCRIPTION
Fixes #62.

The chat-cleanup mixins in ChatComponentMixin assume any GuiMessage that exceeds maxChatHistory is preceded by an older message with a different addedTime. When a single chat message wraps into more visual lines than maxChatHistory (the issue reproduces this via CarryOn attaching the carried block entity's NBT to the player and then /data get entity @s producing a huge component), every entry in trimmedMessages eventually shares the same addedTime. The inner do/while drains the list, then getLast() throws NoSuchElementException and the client disconnects with a packet-handling error.

Guard the inner loop with !list.isEmpty() in both removeOldFromAllMessages and removeOldFromTrimmedMessages so it stops cleanly when the list is fully drained, leaving size = 0 which exits the outer loop.

Verified on a 1.21.1 NeoForge dev client (same code path, easier to repro): a datapack function running one tellraw with ~8000 'a's wraps to >100 lines at maxChatHistory=100. Before the fix, /function repro:crash disconnects with NoSuchElementException at ChatComponent.handler\$...\$discord_chat_mod\$removeOldFromTrimmedMessages, matching the stack in the issue. After the fix, the long message is displayed and chat trimmed normally with no crash. Normal chat traffic (multiple short messages staying under the limit) is unaffected.

Port of #118 to the 1.21.9 branch.