### PR TITLE
fix: prevent client crash on oversized chat messages 1.20.1

### DIFF
--- a/common/src/main/java/com/denisnumb/discord_chat_mod/mixin/ChatComponentMixin.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/mixin/ChatComponentMixin.java
@@ -97,7 +97,7 @@ public abstract class ChatComponentMixin {
             int parentAddedTime = trimmedMessages.get(trimmedMessages.size() - 1).addedTime();
 
             do trimmedMessages.remove(trimmedMessages.size() - 1);
-            while (trimmedMessages.get(trimmedMessages.size() - 1).addedTime() == parentAddedTime);
+            while (!trimmedMessages.isEmpty() && trimmedMessages.get(trimmedMessages.size() - 1).addedTime() == parentAddedTime);
         }
     }
 
@@ -115,7 +115,7 @@ public abstract class ChatComponentMixin {
             int parentAddedTime = allMessages.get(allMessages.size() - 1).addedTime();
 
             do allMessages.remove(allMessages.size() - 1);
-            while (allMessages.get(allMessages.size() - 1).addedTime() == parentAddedTime);
+            while (!allMessages.isEmpty() && allMessages.get(allMessages.size() - 1).addedTime() == parentAddedTime);
         }
     }
 


### PR DESCRIPTION
Fixes #62.

The chat-cleanup mixins in ChatComponentMixin assume any GuiMessage that exceeds maxChatHistory is preceded by an older message with a different addedTime. When a single chat message wraps into more visual lines than maxChatHistory (the issue reproduces this via CarryOn attaching the carried block entity's NBT to the player and then /data get entity @s producing a huge component), every entry in trimmedMessages eventually shares the same addedTime. The inner do/while drains the list, then list.get(size-1) on an empty list throws IndexOutOfBoundsException and the client disconnects with a packet-handling error.

Guard the inner loop with !list.isEmpty() in both removeOldFromAllMessages and removeOldFromTrimmedMessages so it stops cleanly when the list is fully drained, leaving size = 0 which exits the outer loop. 1.20.1 uses list.get(size-1) / list.remove(size-1) instead of the 1.21.x getLast() / removeLast() because it targets Java 17 which predates those methods, but the underlying logic and the bug are identical.

Verified on a 1.21.1 NeoForge dev client (same code path, easier to repro): a datapack function running one tellraw with ~8000 'a's wraps to >100 lines at maxChatHistory=100. Before the fix the client disconnects from the inner-loop crash, after the fix the long message is displayed and chat trimmed normally with no crash. Normal chat traffic (multiple short messages staying under the limit) is unaffected. Compile-checked on 1.20.1 against Java 17.

Port of #118 to the 1.20.1 branch.