### PR TITLE
feat: add option to disable mentioning bots from minecraft chat 1.21.8

### DIFF
--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigComments.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigComments.java
@@ -59,6 +59,13 @@ public class ConfigComments {
              Set to false to disable the presence status entirely (the bot will appear without a custom status).\
             """;
 
+    public static final String MENTION_BOTS_COMMENT
+            = """
+             If true, Discord bots are included in the @-autocomplete shown in Minecraft chat and can be mentioned from the server.\
+
+             Set to false to hide bots from the autocomplete and stop resolving "@botname" in player messages into a Discord mention.\
+            """;
+
     public static final String COMMAND_LOG_ENABLED_COMMENT
             = " Enable logging of commands executed by players to a Discord channel." +
             "\n Only commands from players whose permission level is at least commandLogMinPermissionLevel are logged.";

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigDefaults.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigDefaults.java
@@ -10,6 +10,7 @@ public class ConfigDefaults {
     public static final String MOD_LOCALE_DEFAULT = "en_us";
     public static final int UTC_OFFSET_HOURS_DEFAULT = 0;
     public static final boolean ENABLE_BOT_PRESENCE_STATUS_DEFAULT = true;
+    public static final boolean MENTION_BOTS_DEFAULT = true;
 
     public static final boolean COMMAND_LOG_ENABLED_DEFAULT = false;
     public static final int COMMAND_LOG_MIN_PERMISSION_LEVEL_DEFAULT = 2;

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigProviderImpl.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigProviderImpl.java
@@ -58,6 +58,11 @@ public class ConfigProviderImpl implements IConfigProvider {
     }
 
     @Override
+    public boolean mentionBots() {
+        return CommonConfig.mentionBots;
+    }
+
+    @Override
     public boolean isCommandLogEnabled() {
         return CommonConfig.commandLogEnabled;
     }

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/IConfigProvider.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/IConfigProvider.java
@@ -17,6 +17,7 @@ public interface IConfigProvider {
     String modLocale();
     int utcOffsetHours();
     boolean isBotPresenceStatusEnabled();
+    boolean mentionBots();
 
     boolean isCommandLogEnabled();
     int commandLogMinPermissionLevel();

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/configs/CommonConfig.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/configs/CommonConfig.java
@@ -28,6 +28,7 @@ public class CommonConfig {
     public static String modLocale;
     public static int utcOffsetHours;
     public static boolean enableBotPresenceStatus;
+    public static boolean mentionBots;
     public static boolean commandLogEnabled;
     public static int commandLogMinPermissionLevel;
     public static Set<String> commandLogIgnoredCommands = Collections.emptySet();
@@ -72,6 +73,10 @@ public class CommonConfig {
         enableBotPresenceStatus = commonConfig.getOrElse("enableBotPresenceStatus", ENABLE_BOT_PRESENCE_STATUS_DEFAULT);
         commonConfig.set("enableBotPresenceStatus", enableBotPresenceStatus);
         commonConfig.setComment("enableBotPresenceStatus", ENABLE_BOT_PRESENCE_STATUS_COMMENT);
+
+        mentionBots = commonConfig.getOrElse("mentionBots", MENTION_BOTS_DEFAULT);
+        commonConfig.set("mentionBots", mentionBots);
+        commonConfig.setComment("mentionBots", MENTION_BOTS_COMMENT);
 
         commandLogEnabled = commonConfig.getOrElse("commandLogEnabled", COMMAND_LOG_ENABLED_DEFAULT);
         commonConfig.set("commandLogEnabled", commandLogEnabled);

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/discord/data_providers/ChannelMembersProvider.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/discord/data_providers/ChannelMembersProvider.java
@@ -1,5 +1,6 @@
 package com.denisnumb.discord_chat_mod.discord.data_providers;
 
+import com.denisnumb.discord_chat_mod.config.ConfigProvider;
 import com.denisnumb.discord_chat_mod.discord.DiscordChannelRegistry;
 import com.denisnumb.discord_chat_mod.discord.model.ChannelCategory;
 import com.denisnumb.discord_chat_mod.discord.model.DiscordUserData;
@@ -26,7 +27,10 @@ public class ChannelMembersProvider {
         if (!isDiscordConnected())
             return List.of();
 
+        boolean mentionBots = ConfigProvider.getConfig().mentionBots();
+
         return getList(channelCategoryToParseMembers).stream()
+                .filter(member -> mentionBots || !member.getUser().isBot())
                 .map(member -> new DiscordUserData(
                         getMemberDisplayName(member),
                         member.getUser().getName(),


### PR DESCRIPTION
Fixes #66.

ChannelMembersProvider.getMemberData feeds two things: the @-autocomplete cache that gets pushed to clients via DiscordMentionsTransceiver, and the server-side @name -> Discord-mention resolution in MinecraftUtils.processChatMessage. Both were always built from every guild member the bot can see in the configured chat channel, which included bots themselves. There was no way to hide bots from the autocomplete or stop resolving "@botname" into a real Discord mention.

Adds a new common config option `mentionBots` (default `true` to preserve existing behavior). When set to `false`, ChannelMembersProvider.getMemberData filters out members where Member.getUser().isBot() is true, so bots disappear from the autocomplete suggestion list on the client and "@botname" stays as plain text on the server side as well.

Verified on a 1.21.10 NeoForge dev client + dev server connected to a test guild that contains the mod's own bot as a member. With `mentionBots=true`: typing "@" in chat lists the bot alongside human members. With `mentionBots=false` (after editing the toml and restarting the server): the bot is absent from the autocomplete, and typing "@<botname>" manually leaves it as plain text instead of producing a mention. Human members still autocomplete and resolve correctly in both modes. Compile-checked on this branch.

Port of #124 to the 1.21.8 branch.