### PR TITLE
fix: send server-start message after async discord init completes 1.20.1

### DIFF
--- a/common/src/main/java/com/denisnumb/discord_chat_mod/DiscordChatMod.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/DiscordChatMod.java
@@ -30,6 +30,7 @@ import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.denisnumb.discord_chat_mod.LocaleProvider.getTranslate;
 import static com.denisnumb.discord_chat_mod.MinecraftUtils.*;
@@ -48,6 +49,7 @@ public final class DiscordChatMod {
     public static JDA jda;
     public static MinecraftServer server;
     private static final DiscordEvents discordEvents = new DiscordEvents();
+    private static final AtomicBoolean serverStartPending = new AtomicBoolean(false);
 
     public static void onServerStarting(MinecraftServer minecraftServer) {
         server = minecraftServer;
@@ -62,11 +64,24 @@ public final class DiscordChatMod {
 
     public static void onServerStarted() {
         ServerLogsRetranslator.start();
+        serverStartPending.set(true);
+        trySendServerStartMessage();
+    }
+
+    private static void trySendServerStartMessage() {
+        if (!isDiscordConnected())
+            return;
+        if (DiscordChannelRegistry.getAllContexts().isEmpty())
+            return;
+        if (!serverStartPending.compareAndSet(true, false))
+            return;
+
         getDiscordMessageComponents(MessageType.SERVER_START, Map.of())
                 .ifPresent(components -> sendMessageFromServer(ChannelCategory.SERVER_START_STOP, DiscordChannelRegistry.getAllContexts(), components));
     }
 
     public static void onServerStopped() {
+        serverStartPending.set(false);
         getDiscordMessageComponents(MessageType.SERVER_STOP, Map.of())
                 .ifPresent(components -> sendMessageFromServer(ChannelCategory.SERVER_START_STOP, DiscordChannelRegistry.getAllContexts(), components));
         stopJDA();
@@ -147,6 +162,7 @@ public final class DiscordChatMod {
                 ServerLogsRetranslator.init(config.serverLogsToDiscordLoggingLevel());
 
             LOGGER.info("Discord connected");
+            trySendServerStartMessage();
         } catch (Exception e) {
             logErrorToServer(String.format("DiscordConnectError: %s", e.getMessage()));
             e.printStackTrace();


### PR DESCRIPTION
Follow-up fix to #92 and PRs #93-#98. Sorry I didn't catch this initially.

Moving initJDA off the server-starting thread fixed the watchdog crash loop, but it introduced a race on dedicated servers. SERVER_STARTING spawns initJDA on a background thread; SERVER_STARTED fires very shortly after on the server thread and immediately calls sendMessageFromServer for the SERVER_START message. At that point initJDA is usually still in jda.awaitReady() or before DiscordChannelRegistry.initDiscordChannels has run, so DiscordChannelRegistry.getAllContexts() returns an empty list and the start message is silently dropped. Pre-#93 the init blocked the server-starting thread so this couldn't happen.

Adds an AtomicBoolean serverStartPending and a small trySendServerStartMessage helper. onServerStarted now sets the flag and tries to send; the end of initJDA (after "Discord connected") also tries to send. Whichever path finds JDA connected and channels populated wins a compareAndSet on the flag and emits exactly one start message, so both orderings (init-first or server-started-first) are covered without double-sending. onServerStopped clears the flag so a stop after a failed init does not leave stale state for any subsequent run. The onIntegratedServerStarted path was already sequential within its own thread and is unchanged.

Verified on a 1.21.10 Fabric dev server (same code path): before the fix, server log shows "Done (...)" then "Discord connected" several seconds later, and no server-start embed appears in the test guild. After the fix, the embed arrives in Discord right around when "Discord connected" logs. Verified the server-stop message still posts on /stop. Compile-checked on this branch.

Port of #130 to the 1.20.1 branch.