### PR TITLE
feat: render xaero waypoints on discord with bluemap api integration 1.21.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,11 +24,13 @@ subprojects {
     }
 
     repositories {
-        // Add repositories to retrieve artifacts from in here.
-        // You should only use this when depending on other mods because
-        // Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
-        // See https://docs.gradle.org/current/userguide/declaring_repositories.html
-        // for more information about repositories.
+        maven {
+            name = 'BlueColored'
+            url = 'https://repo.bluecolored.de/releases'
+            content {
+                includeGroup 'de.bluecolored.bluemap'
+            }
+        }
     }
 
     loom {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -11,6 +11,8 @@ dependencies {
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
 
+    compileOnly("de.bluecolored.bluemap:BlueMapAPI:2.7.2")
+
     implementation("net.dv8tion:JDA:6.1.1")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.0")

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/MinecraftUtils.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/MinecraftUtils.java
@@ -31,6 +31,7 @@ import static com.denisnumb.discord_chat_mod.DiscordChatMod.server;
 import static com.denisnumb.discord_chat_mod.chat_style.ChatStyleUtils.applyParametersToTemplate;
 import static com.denisnumb.discord_chat_mod.chat_style.ChatStyleUtils.parseConfigTemplateMarkdown;
 import static com.denisnumb.discord_chat_mod.discord.utils.DiscordMessageUtils.replaceEmojiCodesToDiscordMentions;
+import static com.denisnumb.discord_chat_mod.discord.utils.XaeroWaypointTransformer.transform;
 
 public class MinecraftUtils {
     private static final Logger LOGGER = LogUtils.getLogger();
@@ -57,6 +58,8 @@ public class MinecraftUtils {
 
             forDiscord = MarkdownParser.removeColorTags(replaceEmojiCodesToDiscordMentions(message));
         }
+
+        forDiscord = transform(forDiscord);
 
         Component forMinecraft = new MarkdownToComponentConverter(MarkdownParser.parseMarkdown(message), mentions)
                 .convertMarkdownTokensToComponent();

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigComments.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigComments.java
@@ -138,6 +138,36 @@ public class ConfigComments {
             "\n Default: %s", WEBHOOK_PLAYER_DEFAULT_AVATAR_URL_DEFAULT);
 
     // =================================================================================================================
+    //                                                WEB MAP COMMENTS
+    // =================================================================================================================
+
+    public static final String ENABLE_XAERO_WAYPOINT_PARSING_COMMENT
+            = """
+             If true, raw Xaero waypoint share strings (e.g. "xaero-waypoint:Home:H:957:65:4616:5:false:0:Internal-overworld-waypoints")\
+
+             sent from Minecraft to Discord will be rewritten into a friendlier form: "[Overworld] Home (957, 65, 4616)".\
+
+             If webMapUrlTemplate is also configured, the rewrite becomes a clickable Discord markdown link to the configured map.\
+
+             This only affects the text sent to Discord, the in-game chat is left untouched so Xaero's minimap can still parse the waypoint.\
+            """;
+
+    public static final String WEB_MAP_URL_TEMPLATE_COMMENT
+            = """
+             URL template used when rewriting Xaero waypoints into clickable links on Discord.\
+
+             Leave blank to render waypoints as plain text without a link.\
+
+             Available placeholders: {world}, {x}, {y}, {z}\
+
+             Example for BlueMap: "https://example.com/bluemap/#{world}:{x}:{y}:{z}:1500:0:0:0:0:perspective"\
+
+             The {world} placeholder is resolved automatically when the BlueMap mod is installed on this server.\
+
+             Waypoints from dimensions BlueMap doesn't know about render as plain text without a link.\
+            """;
+
+    // =================================================================================================================
     //                                              DISCORD PROXY COMMENTS
     // =================================================================================================================
 

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigDefaults.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigDefaults.java
@@ -28,6 +28,13 @@ public class ConfigDefaults {
     public static final String WEBHOOK_PLAYER_DEFAULT_AVATAR_URL_DEFAULT = "https://mc-heads.net/avatar/steve_head_png";
 
     // =================================================================================================================
+    //                                                WEB MAP DEFAULTS
+    // =================================================================================================================
+
+    public static final boolean ENABLE_XAERO_WAYPOINT_PARSING_DEFAULT = true;
+    public static final String WEB_MAP_URL_TEMPLATE_DEFAULT = "";
+
+    // =================================================================================================================
     //                                              DISCORD PROXY DEFAULTS
     // =================================================================================================================
 

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigManager.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigManager.java
@@ -15,6 +15,7 @@ import static com.denisnumb.discord_chat_mod.config.configs.DiscordChatStyleConf
 import static com.denisnumb.discord_chat_mod.config.configs.DiscordGuildsConfig.loadDiscordGuildsConfig;
 import static com.denisnumb.discord_chat_mod.config.configs.DiscordProxyConfig.loadDiscordProxyConfig;
 import static com.denisnumb.discord_chat_mod.config.configs.MinecraftChatStyleConfig.loadMinecraftChatStyleConfig;
+import static com.denisnumb.discord_chat_mod.config.configs.WebMapConfig.loadWebMapConfig;
 import static com.denisnumb.discord_chat_mod.config.configs.WebhookModeConfig.loadWebhookModeConfig;
 
 public class ConfigManager {
@@ -62,6 +63,7 @@ public class ConfigManager {
         loadCommonConfig(commonConfig);
         commonConfig.set("guilds", loadDiscordGuildsConfig(commonConfig));
         commonConfig.set("webhookModeConfig", loadWebhookModeConfig(commonConfig));
+        commonConfig.set("webMapConfig", loadWebMapConfig(commonConfig));
         commonConfig.set("discordProxyConfig", loadDiscordProxyConfig(commonConfig));
         commonConfig.set("minecraftChatStyle", loadMinecraftChatStyleConfig(commonConfig));
         commonConfig.set("discordChatStyle", loadDiscordChatStyleConfig(commonConfig));

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigProviderImpl.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigProviderImpl.java
@@ -128,6 +128,16 @@ public class ConfigProviderImpl implements IConfigProvider {
     }
 
     @Override
+    public boolean isXaeroWaypointParsingEnabled() {
+        return WebMapConfig.enableXaeroWaypointParsing;
+    }
+
+    @Override
+    public String webMapUrlTemplate() {
+        return WebMapConfig.webMapUrlTemplate;
+    }
+
+    @Override
     public boolean isMinecraftChatCustomizationEnabled() {
         return MinecraftChatStyleConfig.enableMinecraftChatCustomization;
     }

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/IConfigProvider.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/IConfigProvider.java
@@ -35,6 +35,9 @@ public interface IConfigProvider {
     String proxyUser();
     String proxyPassword();
 
+    boolean isXaeroWaypointParsingEnabled();
+    String webMapUrlTemplate();
+
     boolean isMinecraftChatCustomizationEnabled();
     String minecraftDiscordMessagesStyle();
     String minecraftPlayerMessageStyle();

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/configs/WebMapConfig.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/configs/WebMapConfig.java
@@ -1,0 +1,29 @@
+package com.denisnumb.discord_chat_mod.config.configs;
+
+import com.denisnumb.discord_chat_mod.discord.utils.BluemapMapsRegistry;
+import com.electronwill.nightconfig.core.CommentedConfig;
+
+import static com.denisnumb.discord_chat_mod.config.ConfigComments.*;
+import static com.denisnumb.discord_chat_mod.config.ConfigDefaults.*;
+
+public class WebMapConfig {
+    public static boolean enableXaeroWaypointParsing;
+    public static String webMapUrlTemplate;
+
+    public static CommentedConfig loadWebMapConfig(CommentedConfig commonConfig) {
+        CommentedConfig existedWebMapConfig = commonConfig.getOrElse("webMapConfig", commonConfig.createSubConfig());
+        CommentedConfig webMapConfig = commonConfig.createSubConfig();
+
+        enableXaeroWaypointParsing = existedWebMapConfig.getOrElse("enableXaeroWaypointParsing", ENABLE_XAERO_WAYPOINT_PARSING_DEFAULT);
+        webMapConfig.set("enableXaeroWaypointParsing", enableXaeroWaypointParsing);
+        webMapConfig.setComment("enableXaeroWaypointParsing", ENABLE_XAERO_WAYPOINT_PARSING_COMMENT);
+
+        webMapUrlTemplate = existedWebMapConfig.getOrElse("webMapUrlTemplate", WEB_MAP_URL_TEMPLATE_DEFAULT);
+        webMapConfig.set("webMapUrlTemplate", webMapUrlTemplate);
+        webMapConfig.setComment("webMapUrlTemplate", WEB_MAP_URL_TEMPLATE_COMMENT);
+
+        BluemapMapsRegistry.initialize();
+
+        return webMapConfig;
+    }
+}

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/discord/utils/BluemapApiHook.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/discord/utils/BluemapApiHook.java
@@ -1,0 +1,62 @@
+package com.denisnumb.discord_chat_mod.discord.utils;
+
+import com.mojang.logging.LogUtils;
+import de.bluecolored.bluemap.api.BlueMapAPI;
+import de.bluecolored.bluemap.api.BlueMapMap;
+import org.slf4j.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+class BluemapApiHook {
+    private static final Logger LOGGER = LogUtils.getLogger();
+    private static Consumer<BlueMapAPI> onEnableListener;
+    private static Consumer<BlueMapAPI> onDisableListener;
+
+    static void install() {
+        if (onEnableListener != null) {
+            BlueMapAPI.getInstance().ifPresent(BluemapApiHook::populate);
+            return;
+        }
+        onEnableListener = BluemapApiHook::populate;
+        onDisableListener = api -> BluemapMapsRegistry.setMappings(Map.of());
+        BlueMapAPI.onEnable(onEnableListener);
+        BlueMapAPI.onDisable(onDisableListener);
+        BlueMapAPI.getInstance().ifPresent(BluemapApiHook::populate);
+    }
+
+    static void uninstall() {
+        if (onEnableListener != null) {
+            BlueMapAPI.unregisterListener(onEnableListener);
+            onEnableListener = null;
+        }
+        if (onDisableListener != null) {
+            BlueMapAPI.unregisterListener(onDisableListener);
+            onDisableListener = null;
+        }
+        BluemapMapsRegistry.setMappings(Map.of());
+    }
+
+    private static void populate(BlueMapAPI api) {
+        Map<String, String> resolved = new HashMap<>();
+        for (BlueMapMap map : api.getMaps()) {
+            String dimension = parseDimension(map.getWorld().getId());
+            if (dimension == null) {
+                LOGGER.warn("BlueMap map \"{}\" has unrecognized world id format \"{}\", skipping",
+                        map.getId(), map.getWorld().getId());
+                continue;
+            }
+            resolved.putIfAbsent(dimension, map.getId());
+        }
+        BluemapMapsRegistry.setMappings(resolved);
+    }
+
+    private static String parseDimension(String worldId) {
+        if (worldId == null) return null;
+        int hash = worldId.indexOf('#');
+        if (hash >= 0 && hash < worldId.length() - 1)
+            return worldId.substring(hash + 1);
+        return null;
+    }
+}

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/discord/utils/BluemapMapsRegistry.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/discord/utils/BluemapMapsRegistry.java
@@ -1,0 +1,36 @@
+package com.denisnumb.discord_chat_mod.discord.utils;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class BluemapMapsRegistry {
+    private static final String BLUEMAP_API_CLASS = "de.bluecolored.bluemap.api.BlueMapAPI";
+
+    private static volatile Map<String, String> dimensionToMapId = Map.of();
+    private static Boolean bluemapAvailable;
+
+    public static void initialize() {
+        if (!isBluemapAvailable()) return;
+        BluemapApiHook.install();
+    }
+
+    public static Optional<String> getMapId(String dimensionId) {
+        return Optional.ofNullable(dimensionToMapId.get(dimensionId));
+    }
+
+    static void setMappings(Map<String, String> mappings) {
+        dimensionToMapId = Map.copyOf(mappings);
+    }
+
+    private static boolean isBluemapAvailable() {
+        if (bluemapAvailable == null) {
+            try {
+                Class.forName(BLUEMAP_API_CLASS, false, BluemapMapsRegistry.class.getClassLoader());
+                bluemapAvailable = true;
+            } catch (ClassNotFoundException e) {
+                bluemapAvailable = false;
+            }
+        }
+        return bluemapAvailable;
+    }
+}

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/discord/utils/XaeroWaypointTransformer.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/discord/utils/XaeroWaypointTransformer.java
@@ -1,0 +1,115 @@
+package com.denisnumb.discord_chat_mod.discord.utils;
+
+import com.denisnumb.discord_chat_mod.config.ConfigProvider;
+import com.denisnumb.discord_chat_mod.config.IConfigProvider;
+
+import java.util.Locale;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class XaeroWaypointTransformer {
+    private static final Pattern WAYPOINT_PATTERN = Pattern.compile(
+            "xaero-waypoint:([^:]+):[^:]*:(-?\\d+|~):(-?\\d+|~):(-?\\d+|~):[^:]*:[^:]*:[^:]*:(Internal-[\\w%$-]+)"
+    );
+
+    private static final Pattern MODDED_CATEGORY = Pattern.compile(
+            "Internal-dim%([\\w-]+)\\$([\\w-]+)-waypoints"
+    );
+
+    private static final int DEFAULT_Y_FALLBACK = 64;
+
+    private record Dimension(String id, String label) {}
+
+    public static String transform(String text) {
+        if (text == null || !text.contains("xaero-waypoint:"))
+            return text;
+
+        IConfigProvider config = ConfigProvider.getConfig();
+        if (config == null || !config.isXaeroWaypointParsingEnabled())
+            return text;
+
+        Matcher matcher = WAYPOINT_PATTERN.matcher(text);
+        StringBuilder result = new StringBuilder();
+        while (matcher.find()) {
+            String name = matcher.group(1);
+            int x = parseCoord(matcher.group(2), 0);
+            int y = parseCoord(matcher.group(3), DEFAULT_Y_FALLBACK);
+            int z = parseCoord(matcher.group(4), 0);
+            Dimension dimension = resolveDimension(matcher.group(5));
+
+            String replacement = renderWaypoint(config, name, x, y, z, dimension);
+            matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(result);
+        return result.toString();
+    }
+
+    private static int parseCoord(String raw, int fallback) {
+        if ("~".equals(raw)) return fallback;
+        try {
+            return Integer.parseInt(raw);
+        } catch (NumberFormatException e) {
+            return fallback;
+        }
+    }
+
+    private static Dimension resolveDimension(String xaeroCategory) {
+        Matcher m = MODDED_CATEGORY.matcher(xaeroCategory);
+        if (m.matches()) {
+            String namespace = m.group(1).replace('-', '_');
+            String path = m.group(2).replace('-', '_');
+            return new Dimension(namespace + ":" + path, prettifyPath(path));
+        }
+        String id = xaeroCategory.contains("nether") ? "minecraft:the_nether"
+                : xaeroCategory.contains("end") ? "minecraft:the_end"
+                : "minecraft:overworld";
+        return new Dimension(id, prettifyPath(pathOf(id)));
+    }
+
+    private static String pathOf(String dimensionId) {
+        int colon = dimensionId.indexOf(':');
+        return colon < 0 ? dimensionId : dimensionId.substring(colon + 1);
+    }
+
+    private static String prettifyPath(String path) {
+        String trimmed = path.startsWith("the_") ? path.substring(4) : path;
+        StringBuilder out = new StringBuilder();
+        for (String part : trimmed.split("_")) {
+            if (part.isEmpty()) continue;
+            if (!out.isEmpty()) out.append(' ');
+            out.append(Character.toUpperCase(part.charAt(0))).append(part.substring(1).toLowerCase(Locale.ROOT));
+        }
+        return out.isEmpty() ? path : out.toString();
+    }
+
+    private static String renderWaypoint(IConfigProvider config, String name, int x, int y, int z, Dimension dimension) {
+        String safeName = escapeMarkdownBrackets(name);
+        String coords = String.format("%d, %d, %d", x, y, z);
+        String label = dimension.label();
+
+        String template = config.webMapUrlTemplate();
+        if (template == null || template.isBlank())
+            return String.format("[%s] %s (%s)", label, safeName, coords);
+
+        Optional<String> mapId = resolveMapId(dimension);
+        if (mapId.isEmpty())
+            return String.format("[%s] %s (%s)", label, safeName, coords);
+
+        String url = template
+                .replace("{world}", mapId.get())
+                .replace("{x}", Integer.toString(x))
+                .replace("{y}", Integer.toString(y))
+                .replace("{z}", Integer.toString(z));
+
+        return String.format("[%s] [%s (%s)](<%s>)", label, safeName, coords, url);
+    }
+
+    private static Optional<String> resolveMapId(Dimension dimension) {
+        return BluemapMapsRegistry.getMapId(dimension.id());
+    }
+
+    private static String escapeMarkdownBrackets(String name) {
+        return name.replace("[", "\\[").replace("]", "\\]");
+    }
+}


### PR DESCRIPTION
Refs #136.

> [!NOTE]
> This is a pseudo / example implementation, working but minimal. It exists to gauge interest in the idea before investing in a full implementation. If you'd like the feature, the proper version would need follow-ups (see notes below). A second example PR exists with a no-dependency variant for comparison.

A waypoint shared from Xaero's Minimap currently ends up on Discord as the raw protocol string `xaero-waypoint:Home:H:957:65:4616:5:false:0:Internal-overworld-waypoints`. This patch rewrites it on the way out to either `[Overworld] Home (957, 65, 4616)` (plain text) or `[Overworld] [Home (957, 65, 4616)](<url>)` when a web-map URL template is configured. The in-game Component is left untouched so Xaero's minimap can still parse the waypoint client-side.

This variant integrates with the BlueMap mod through its public Java API (`de.bluecolored.bluemap.api.BlueMapAPI`) as a `compileOnly` dependency, scoped to the `de.bluecolored.bluemap` group. When BlueMap is installed, the mod registers an `onEnable` listener and queries `api.getMaps()` for the loaded maps, resolving Minecraft dimension ids to BlueMap map ids automatically (covering modded dimensions and renamed map ids without per-dimension config). When BlueMap is absent the BlueMap-touching class is never loaded thanks to a `Class.forName` guard, so there is no runtime impact and the shaded jar does not bundle BlueMap classes.

Two new config keys under `[webMapConfig]`: `enableXaeroWaypointParsing` (master toggle, default true) and `webMapUrlTemplate` (URL template with `{world}`, `{x}`, `{y}`, `{z}` placeholders, blank by default which means plain-text rendering). No per-dimension mapping is required from the admin; BlueMap provides it.

Tested locally on a 1.21.1 NeoForge dev server with BlueMap 5.7, Xaero's Minimap, and modded dimensions (Northstar, the_afterdark). Vanilla and modded waypoints both resolve to the correct BlueMap map id. Plain-text rendering verified by leaving `webMapUrlTemplate` blank. Both bot-token and webhook Discord modes render the link correctly with the `<...>` wrap suppressing the link preview.

Follow-ups if approved:
- Locale strings for the auto-derived dimension labels (currently hard-coded English prettification)
- Decide on the default for `enableXaeroWaypointParsing` (true is friendlier, false is opt-in)
- Decide whether to keep BlueMap as the only auto-detection target or add fallbacks for non-BlueMap web maps (Dynmap, Pl3xMap, Squaremap)
- Multi-version ports per the existing convention