### PR TITLE
feat: render xaero waypoints on discord with manual web map config 1.21.1

### DIFF
--- a/common/src/main/java/com/denisnumb/discord_chat_mod/MinecraftUtils.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/MinecraftUtils.java
@@ -31,6 +31,7 @@ import static com.denisnumb.discord_chat_mod.DiscordChatMod.server;
 import static com.denisnumb.discord_chat_mod.chat_style.ChatStyleUtils.applyParametersToTemplate;
 import static com.denisnumb.discord_chat_mod.chat_style.ChatStyleUtils.parseConfigTemplateMarkdown;
 import static com.denisnumb.discord_chat_mod.discord.utils.DiscordMessageUtils.replaceEmojiCodesToDiscordMentions;
+import static com.denisnumb.discord_chat_mod.discord.utils.XaeroWaypointTransformer.transform;
 
 public class MinecraftUtils {
     private static final Logger LOGGER = LogUtils.getLogger();
@@ -57,6 +58,8 @@ public class MinecraftUtils {
 
             forDiscord = MarkdownParser.removeColorTags(replaceEmojiCodesToDiscordMentions(message));
         }
+
+        forDiscord = transform(forDiscord);
 
         Component forMinecraft = new MarkdownToComponentConverter(MarkdownParser.parseMarkdown(message), mentions)
                 .convertMarkdownTokensToComponent();

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigComments.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigComments.java
@@ -138,6 +138,49 @@ public class ConfigComments {
             "\n Default: %s", WEBHOOK_PLAYER_DEFAULT_AVATAR_URL_DEFAULT);
 
     // =================================================================================================================
+    //                                                WEB MAP COMMENTS
+    // =================================================================================================================
+
+    public static final String ENABLE_XAERO_WAYPOINT_PARSING_COMMENT
+            = """
+             If true, raw Xaero waypoint share strings (e.g. "xaero-waypoint:Home:H:957:65:4616:5:false:0:Internal-overworld-waypoints")\
+
+             sent from Minecraft to Discord will be rewritten into a friendlier form: "[Overworld] Home (957, 65, 4616)".\
+
+             If webMapUrlTemplate is also configured and the dimension is listed in [webMapConfig.dimensions], the\
+
+             rewrite becomes a clickable Discord markdown link to the configured web map.\
+
+             This only affects the text sent to Discord, the in-game chat is left untouched so Xaero's minimap can\
+
+             still parse the waypoint.\
+            """;
+
+    public static final String WEB_MAP_URL_TEMPLATE_COMMENT
+            = """
+             URL template used when rewriting Xaero waypoints into clickable links on Discord.\
+
+             Leave blank to render waypoints as plain text without a link.\
+
+             Available placeholders: {world}, {x}, {y}, {z}\
+
+             Example for BlueMap: "https://example.com/bluemap/#{world}:{x}:{y}:{z}:1500:0:0:0:0:perspective"\
+
+             Example for Dynmap: "https://example.com/dynmap/?worldname={world}&mapname=flat&zoom=6&x={x}&y={y}&z={z}"\
+            """;
+
+    public static final String WEB_MAP_DIMENSIONS_COMMENT
+            = """
+             Mapping of Minecraft dimension ids to web-map identifiers. Each key is a full Minecraft dimension id,\
+
+             each value is the identifier used by your web map (substituted into {world} in webMapUrlTemplate).\
+
+             Add entries for modded dimensions as needed. Dimensions not listed here render as plain text without\
+
+             a link. Labels shown in the [Dimension] prefix are derived from the dimension id automatically.\
+            """;
+
+    // =================================================================================================================
     //                                              DISCORD PROXY COMMENTS
     // =================================================================================================================
 

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigDefaults.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigDefaults.java
@@ -28,6 +28,13 @@ public class ConfigDefaults {
     public static final String WEBHOOK_PLAYER_DEFAULT_AVATAR_URL_DEFAULT = "https://mc-heads.net/avatar/steve_head_png";
 
     // =================================================================================================================
+    //                                                WEB MAP DEFAULTS
+    // =================================================================================================================
+
+    public static final boolean ENABLE_XAERO_WAYPOINT_PARSING_DEFAULT = true;
+    public static final String WEB_MAP_URL_TEMPLATE_DEFAULT = "";
+
+    // =================================================================================================================
     //                                              DISCORD PROXY DEFAULTS
     // =================================================================================================================
 

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigManager.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigManager.java
@@ -15,6 +15,7 @@ import static com.denisnumb.discord_chat_mod.config.configs.DiscordChatStyleConf
 import static com.denisnumb.discord_chat_mod.config.configs.DiscordGuildsConfig.loadDiscordGuildsConfig;
 import static com.denisnumb.discord_chat_mod.config.configs.DiscordProxyConfig.loadDiscordProxyConfig;
 import static com.denisnumb.discord_chat_mod.config.configs.MinecraftChatStyleConfig.loadMinecraftChatStyleConfig;
+import static com.denisnumb.discord_chat_mod.config.configs.WebMapConfig.loadWebMapConfig;
 import static com.denisnumb.discord_chat_mod.config.configs.WebhookModeConfig.loadWebhookModeConfig;
 
 public class ConfigManager {
@@ -62,6 +63,7 @@ public class ConfigManager {
         loadCommonConfig(commonConfig);
         commonConfig.set("guilds", loadDiscordGuildsConfig(commonConfig));
         commonConfig.set("webhookModeConfig", loadWebhookModeConfig(commonConfig));
+        commonConfig.set("webMapConfig", loadWebMapConfig(commonConfig));
         commonConfig.set("discordProxyConfig", loadDiscordProxyConfig(commonConfig));
         commonConfig.set("minecraftChatStyle", loadMinecraftChatStyleConfig(commonConfig));
         commonConfig.set("discordChatStyle", loadDiscordChatStyleConfig(commonConfig));

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigProviderImpl.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigProviderImpl.java
@@ -128,6 +128,21 @@ public class ConfigProviderImpl implements IConfigProvider {
     }
 
     @Override
+    public boolean isXaeroWaypointParsingEnabled() {
+        return WebMapConfig.enableXaeroWaypointParsing;
+    }
+
+    @Override
+    public String webMapUrlTemplate() {
+        return WebMapConfig.webMapUrlTemplate;
+    }
+
+    @Override
+    public java.util.Map<String, String> webMapDimensions() {
+        return WebMapConfig.webMapDimensions;
+    }
+
+    @Override
     public boolean isMinecraftChatCustomizationEnabled() {
         return MinecraftChatStyleConfig.enableMinecraftChatCustomization;
     }

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/IConfigProvider.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/IConfigProvider.java
@@ -35,6 +35,10 @@ public interface IConfigProvider {
     String proxyUser();
     String proxyPassword();
 
+    boolean isXaeroWaypointParsingEnabled();
+    String webMapUrlTemplate();
+    java.util.Map<String, String> webMapDimensions();
+
     boolean isMinecraftChatCustomizationEnabled();
     String minecraftDiscordMessagesStyle();
     String minecraftPlayerMessageStyle();

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/configs/WebMapConfig.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/configs/WebMapConfig.java
@@ -1,0 +1,55 @@
+package com.denisnumb.discord_chat_mod.config.configs;
+
+import com.electronwill.nightconfig.core.CommentedConfig;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static com.denisnumb.discord_chat_mod.config.ConfigComments.*;
+import static com.denisnumb.discord_chat_mod.config.ConfigDefaults.*;
+
+public class WebMapConfig {
+    public static boolean enableXaeroWaypointParsing;
+    public static String webMapUrlTemplate;
+    public static volatile Map<String, String> webMapDimensions = Map.of();
+
+    public static CommentedConfig loadWebMapConfig(CommentedConfig commonConfig) {
+        CommentedConfig existedWebMapConfig = commonConfig.getOrElse("webMapConfig", commonConfig.createSubConfig());
+        CommentedConfig webMapConfig = commonConfig.createSubConfig();
+
+        enableXaeroWaypointParsing = existedWebMapConfig.getOrElse("enableXaeroWaypointParsing", ENABLE_XAERO_WAYPOINT_PARSING_DEFAULT);
+        webMapConfig.set("enableXaeroWaypointParsing", enableXaeroWaypointParsing);
+        webMapConfig.setComment("enableXaeroWaypointParsing", ENABLE_XAERO_WAYPOINT_PARSING_COMMENT);
+
+        webMapUrlTemplate = existedWebMapConfig.getOrElse("webMapUrlTemplate", WEB_MAP_URL_TEMPLATE_DEFAULT);
+        webMapConfig.set("webMapUrlTemplate", webMapUrlTemplate);
+        webMapConfig.setComment("webMapUrlTemplate", WEB_MAP_URL_TEMPLATE_COMMENT);
+
+        CommentedConfig dimensions = existedWebMapConfig.get("dimensions");
+        if (dimensions == null)
+            dimensions = defaultDimensionsConfig(commonConfig);
+        webMapConfig.set("dimensions", dimensions);
+        webMapConfig.setComment("dimensions", WEB_MAP_DIMENSIONS_COMMENT);
+        webMapDimensions = readDimensions(dimensions);
+
+        return webMapConfig;
+    }
+
+    private static CommentedConfig defaultDimensionsConfig(CommentedConfig parent) {
+        CommentedConfig dims = parent.createSubConfig();
+        dims.set("minecraft:overworld", "world");
+        dims.set("minecraft:the_nether", "world_the_nether");
+        dims.set("minecraft:the_end", "world_the_end");
+        return dims;
+    }
+
+    private static Map<String, String> readDimensions(CommentedConfig dimensions) {
+        Map<String, String> result = new LinkedHashMap<>();
+        for (CommentedConfig.Entry entry : dimensions.entrySet()) {
+            Object value = entry.getValue();
+            if (value instanceof String s && !s.isBlank())
+                result.put(entry.getKey(), s);
+        }
+        return Map.copyOf(result);
+    }
+}

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/discord/utils/XaeroWaypointTransformer.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/discord/utils/XaeroWaypointTransformer.java
@@ -1,0 +1,116 @@
+package com.denisnumb.discord_chat_mod.discord.utils;
+
+import com.denisnumb.discord_chat_mod.config.ConfigProvider;
+import com.denisnumb.discord_chat_mod.config.IConfigProvider;
+
+import java.util.Locale;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class XaeroWaypointTransformer {
+    private static final Pattern WAYPOINT_PATTERN = Pattern.compile(
+            "xaero-waypoint:([^:]+):[^:]*:(-?\\d+|~):(-?\\d+|~):(-?\\d+|~):[^:]*:[^:]*:[^:]*:(Internal-[\\w%$-]+)"
+    );
+
+    private static final Pattern MODDED_CATEGORY = Pattern.compile(
+            "Internal-dim%([\\w-]+)\\$([\\w-]+)-waypoints"
+    );
+
+    private static final int DEFAULT_Y_FALLBACK = 64;
+
+    private record Dimension(String id, String label) {}
+
+    public static String transform(String text) {
+        if (text == null || !text.contains("xaero-waypoint:"))
+            return text;
+
+        IConfigProvider config = ConfigProvider.getConfig();
+        if (config == null || !config.isXaeroWaypointParsingEnabled())
+            return text;
+
+        Matcher matcher = WAYPOINT_PATTERN.matcher(text);
+        StringBuilder result = new StringBuilder();
+        while (matcher.find()) {
+            String name = matcher.group(1);
+            int x = parseCoord(matcher.group(2), 0);
+            int y = parseCoord(matcher.group(3), DEFAULT_Y_FALLBACK);
+            int z = parseCoord(matcher.group(4), 0);
+            Dimension dimension = resolveDimension(matcher.group(5));
+
+            String replacement = renderWaypoint(config, name, x, y, z, dimension);
+            matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(result);
+        return result.toString();
+    }
+
+    private static int parseCoord(String raw, int fallback) {
+        if ("~".equals(raw)) return fallback;
+        try {
+            return Integer.parseInt(raw);
+        } catch (NumberFormatException e) {
+            return fallback;
+        }
+    }
+
+    private static Dimension resolveDimension(String xaeroCategory) {
+        Matcher m = MODDED_CATEGORY.matcher(xaeroCategory);
+        if (m.matches()) {
+            String namespace = m.group(1).replace('-', '_');
+            String path = m.group(2).replace('-', '_');
+            return new Dimension(namespace + ":" + path, prettifyPath(path));
+        }
+        String id = xaeroCategory.contains("nether") ? "minecraft:the_nether"
+                : xaeroCategory.contains("end") ? "minecraft:the_end"
+                : "minecraft:overworld";
+        return new Dimension(id, prettifyPath(pathOf(id)));
+    }
+
+    private static String pathOf(String dimensionId) {
+        int colon = dimensionId.indexOf(':');
+        return colon < 0 ? dimensionId : dimensionId.substring(colon + 1);
+    }
+
+    private static String prettifyPath(String path) {
+        String trimmed = path.startsWith("the_") ? path.substring(4) : path;
+        StringBuilder out = new StringBuilder();
+        for (String part : trimmed.split("_")) {
+            if (part.isEmpty()) continue;
+            if (!out.isEmpty()) out.append(' ');
+            out.append(Character.toUpperCase(part.charAt(0))).append(part.substring(1).toLowerCase(Locale.ROOT));
+        }
+        return out.isEmpty() ? path : out.toString();
+    }
+
+    private static String renderWaypoint(IConfigProvider config, String name, int x, int y, int z, Dimension dimension) {
+        String safeName = escapeMarkdownBrackets(name);
+        String coords = String.format("%d, %d, %d", x, y, z);
+        String label = dimension.label();
+
+        String template = config.webMapUrlTemplate();
+        if (template == null || template.isBlank())
+            return String.format("[%s] %s (%s)", label, safeName, coords);
+
+        Optional<String> mapId = resolveMapId(config, dimension);
+        if (mapId.isEmpty())
+            return String.format("[%s] %s (%s)", label, safeName, coords);
+
+        String url = template
+                .replace("{world}", mapId.get())
+                .replace("{x}", Integer.toString(x))
+                .replace("{y}", Integer.toString(y))
+                .replace("{z}", Integer.toString(z));
+
+        return String.format("[%s] [%s (%s)](<%s>)", label, safeName, coords, url);
+    }
+
+    private static Optional<String> resolveMapId(IConfigProvider config, Dimension dimension) {
+        String mapId = config.webMapDimensions().get(dimension.id());
+        return mapId == null || mapId.isBlank() ? Optional.empty() : Optional.of(mapId);
+    }
+
+    private static String escapeMarkdownBrackets(String name) {
+        return name.replace("[", "\\[").replace("]", "\\]");
+    }
+}


### PR DESCRIPTION
Refs #136. Alternative to #137 with no external mod dependency.

> [!NOTE]
> This is a pseudo / example implementation, working but minimal. It exists to gauge interest in the idea before investing in a full implementation. If you'd like the feature, the proper version would need follow-ups (see notes below). A second example PR (#137) exists with a BlueMap API variant for comparison.

A waypoint shared from Xaero's Minimap currently ends up on Discord as the raw protocol string `xaero-waypoint:Home:H:957:65:4616:5:false:0:Internal-overworld-waypoints`. This patch rewrites it on the way out to either `[Overworld] Home (957, 65, 4616)` (plain text) or `[Overworld] [Home (957, 65, 4616)](<url>)` when a web-map URL template is configured. The in-game Component is left untouched so Xaero's minimap can still parse the waypoint client-side.

This variant is self-contained with no external dependencies and no integration with the BlueMap mod. The admin specifies the dimension to web-map id mapping manually under `[webMapConfig.dimensions]`. The defaults cover the three vanilla dimensions with common Paper/Spigot world names; modded dimensions or non-default BlueMap/Dynmap map ids are added as new rows. The same URL template approach works for BlueMap, Dynmap, Pl3xMap, Squaremap, or anything else with a coordinate-based URL.

Three new config keys under `[webMapConfig]`: `enableXaeroWaypointParsing`, `webMapUrlTemplate`, and the `[webMapConfig.dimensions]` sub-table (keyed by full Minecraft dimension id, value is the web-map identifier substituted into `{world}`).

Tested locally on a 1.21.1 NeoForge dev server with Xaero's Minimap and modded dimensions (Northstar, the_afterdark). The regex parses both vanilla (`Internal-overworld-waypoints`) and modded (`Internal-dim%northstar$mars-waypoints`) Xaero category formats. Manual entries for `northstar:mars` etc. resolve to the right map id; dimensions without an entry render as plain text. Both bot-token and webhook Discord modes render the link correctly with the `<...>` wrap suppressing the link preview.

Follow-ups if approved:
- Locale strings for the auto-derived dimension labels (currently hard-coded English prettification)
- Decide on the default for `enableXaeroWaypointParsing` (true is friendlier, false is opt-in)
- Multi-version ports per the existing convention