### PR TITLE
feat: translate minecraft formatting codes to discord markdown 1.20.1

### DIFF
--- a/common/src/main/java/com/denisnumb/discord_chat_mod/MinecraftUtils.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/MinecraftUtils.java
@@ -8,6 +8,7 @@ import com.denisnumb.discord_chat_mod.discord.model.DiscordMentionData;
 import com.denisnumb.discord_chat_mod.discord.model.DiscordUserData;
 import com.denisnumb.discord_chat_mod.markdown.MarkdownParser;
 import com.denisnumb.discord_chat_mod.markdown.MarkdownToComponentConverter;
+import com.denisnumb.discord_chat_mod.markdown.MinecraftFormattingConverter;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.logging.LogUtils;
@@ -57,6 +58,7 @@ public class MinecraftUtils {
             }};
 
             forDiscord = MarkdownParser.removeColorTags(replaceEmojiCodesToDiscordMentions(message));
+            forDiscord = MinecraftFormattingConverter.toDiscordMarkdown(forDiscord);
         }
 
         Component forMinecraft = new MarkdownToComponentConverter(MarkdownParser.parseMarkdown(message), mentions)

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/markdown/MinecraftFormattingConverter.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/markdown/MinecraftFormattingConverter.java
@@ -1,0 +1,62 @@
+package com.denisnumb.discord_chat_mod.markdown;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class MinecraftFormattingConverter {
+    private static final char SECTION_SIGN = '\u00A7';
+
+    private MinecraftFormattingConverter() {
+    }
+
+    public static String toDiscordMarkdown(String text) {
+        if (text.indexOf(SECTION_SIGN) < 0)
+            return text;
+
+        StringBuilder result = new StringBuilder(text.length());
+        List<String> openTokens = new ArrayList<>();
+
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
+
+            if (c != SECTION_SIGN) {
+                result.append(c);
+                continue;
+            }
+
+            if (i + 1 >= text.length())
+                break;
+
+            char code = Character.toLowerCase(text.charAt(++i));
+            String token = switch (code) {
+                case 'l' -> "**";
+                case 'o' -> "*";
+                case 'n' -> "__";
+                case 'm' -> "~~";
+                default -> null;
+            };
+
+            if (token != null) {
+                if (!openTokens.contains(token)) {
+                    openTokens.add(token);
+                    result.append(token);
+                }
+            } else if (code == 'r' || isColorCode(code)) {
+                closeOpenTokens(result, openTokens);
+            }
+        }
+
+        closeOpenTokens(result, openTokens);
+        return result.toString();
+    }
+
+    private static boolean isColorCode(char code) {
+        return (code >= '0' && code <= '9') || (code >= 'a' && code <= 'f');
+    }
+
+    private static void closeOpenTokens(StringBuilder result, List<String> openTokens) {
+        for (int i = openTokens.size() - 1; i >= 0; i--)
+            result.append(openTokens.get(i));
+        openTokens.clear();
+    }
+}


### PR DESCRIPTION
Fixes #71.

Adds support for Minecraft `§` formatting codes in chat relayed to Discord. `§l`/`§o`/`§n`/`§m` become Discord markdown (`**`, `*`, `__`, `~~`); `§r` and color codes close any open formatting and are stripped, since Discord has no inline text color. This runs unconditionally, consistent with the existing markdown handling in `processChatMessage`.

The suggestion also covered mapping the first color code to the embed color; that part was left out, since player chat is relayed as plain message content rather than an embed.

Tested on a 1.21.1 dev server with Text Formatting Everywhere: bold/italic/underline/strikethrough, `§r` reset, stacked formats, and color-code stripping all relay correctly. Build verified on all six version branches.

Port of #140 to the `1.20.1` branch.