### PR TITLE
fix: silence JDA fallback logger and cache flag warnings 1.20.1

### DIFF
--- a/common/src/main/java/com/denisnumb/discord_chat_mod/DiscordChatMod.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/DiscordChatMod.java
@@ -20,6 +20,8 @@ import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.dv8tion.jda.api.utils.ChunkingFilter;
 import net.dv8tion.jda.api.utils.MemberCachePolicy;
+import net.dv8tion.jda.api.utils.cache.CacheFlag;
+import net.dv8tion.jda.internal.utils.JDALogger;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.server.MinecraftServer;
 import okhttp3.Credentials;
@@ -113,6 +115,7 @@ public final class DiscordChatMod {
 
     public static void initJDA(){
         try {
+            JDALogger.setFallbackLoggerEnabled(false);
             IConfigProvider config = ConfigProvider.getConfig();
 
             WebSocketFactory webSocketFactory = new WebSocketFactory();
@@ -146,6 +149,7 @@ public final class DiscordChatMod {
                             GatewayIntent.GUILD_EXPRESSIONS)
                     .setChunkingFilter(ChunkingFilter.ALL)
                     .setMemberCachePolicy(MemberCachePolicy.ALL)
+                    .disableCache(CacheFlag.VOICE_STATE, CacheFlag.SCHEDULED_EVENTS)
                     .addEventListeners(discordEvents)
                     .setHttpClientBuilder(httpClientBuilder)
                     .setWebsocketFactory(webSocketFactory)


### PR DESCRIPTION
Fixes #55.

JDA's SLF4J provider lookup fails inside the mod classloader, so on every startup it prints a fallback-logger warning block recommending `JDALogger.setFallbackLoggerEnabled(false)`. It also logs `CacheFlag` warnings because `VOICE_STATE` and `SCHEDULED_EVENTS` are enabled by default without the matching gateway intents, neither of which the mod uses.

Disables the JDA fallback logger before building JDA, and disables the two unused cache flags on the `JDABuilder`. Both are JDA's own recommended way to clear these warnings.

Tested on a 1.21.1 dev server: the SLF4J fallback block and the `CacheFlag` warnings no longer appear on startup, and the Discord bridge connects and works normally. Build verified on all six version branches.

Port of #146 to the `1.20.1` branch.