### PR TITLE
feat: add player position and dimension message parameters 1.21.10

### DIFF
--- a/common/src/main/java/com/denisnumb/discord_chat_mod/MinecraftEvents.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/MinecraftEvents.java
@@ -75,7 +75,7 @@ public class MinecraftEvents {
         }
 
         if (ConfigProvider.getConfig().isMinecraftChatCustomizationEnabled())
-            return getStyledDeathMessage(components);
+            return getStyledDeathMessage(components, entity);
         return Optional.empty();
     }
 

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/chat_style/ChatStyleUtils.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/chat_style/ChatStyleUtils.java
@@ -4,11 +4,14 @@ import com.denisnumb.discord_chat_mod.config.ConfigProvider;
 import com.denisnumb.discord_chat_mod.config.IConfigProvider;
 import com.denisnumb.discord_chat_mod.markdown.MarkdownParser;
 import com.denisnumb.discord_chat_mod.markdown.MarkdownToComponentConverter;
+import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.ChatType;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
 import java.time.Instant;
@@ -25,6 +28,10 @@ import static com.denisnumb.discord_chat_mod.LocaleProvider.getTranslate;
 import static com.denisnumb.discord_chat_mod.chat_style.CustomChatTypeRegistry.*;
 import static com.denisnumb.discord_chat_mod.chat_style.Parameters.COMMANDS_MESSAGE_DISPLAY_INCOMING;
 import static com.denisnumb.discord_chat_mod.chat_style.Parameters.COMMANDS_MESSAGE_DISPLAY_OUTGOING;
+import static com.denisnumb.discord_chat_mod.chat_style.Parameters.X;
+import static com.denisnumb.discord_chat_mod.chat_style.Parameters.Y;
+import static com.denisnumb.discord_chat_mod.chat_style.Parameters.Z;
+import static com.denisnumb.discord_chat_mod.chat_style.Parameters.DIMENSION;
 
 public class ChatStyleUtils {
     public static Map<String, Style> parseTemplateParameterStyles(MutableComponent template, String... parameters) {
@@ -148,6 +155,43 @@ public class ChatStyleUtils {
         ZoneOffset offset = ZoneOffset.ofHours(ConfigProvider.getConfig().utcOffsetHours());
 
         return nowUtc.atOffset(offset);
+    }
+
+    public static Map<String, String> buildPositionParameters(@Nullable Entity entity){
+        HashMap<String, String> result = new HashMap<>();
+
+        if (entity == null){
+            result.put(X, "");
+            result.put(Y, "");
+            result.put(Z, "");
+            result.put(DIMENSION, "");
+            return result;
+        }
+
+        BlockPos pos = entity.blockPosition();
+        result.put(X, String.valueOf(pos.getX()));
+        result.put(Y, String.valueOf(pos.getY()));
+        result.put(Z, String.valueOf(pos.getZ()));
+        result.put(DIMENSION, getDimensionName(entity.level().dimension()));
+
+        return result;
+    }
+
+    private static String getDimensionName(ResourceKey<Level> dimension){
+        if (dimension == Level.OVERWORLD)
+            return "Overworld";
+        if (dimension == Level.NETHER)
+            return "Nether";
+        if (dimension == Level.END)
+            return "End";
+        return prettifyDimensionPath(dimension.location().getPath());
+    }
+
+    private static String prettifyDimensionPath(String path){
+        return Arrays.stream(path.split("_"))
+                .filter(word -> !word.isEmpty())
+                .map(word -> Character.toUpperCase(word.charAt(0)) + word.substring(1))
+                .collect(Collectors.joining(" "));
     }
 
     @SafeVarargs

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/chat_style/MinecraftChatStyleProvider.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/chat_style/MinecraftChatStyleProvider.java
@@ -7,6 +7,7 @@ import net.minecraft.advancements.AdvancementType;
 import net.minecraft.advancements.DisplayInfo;
 import net.minecraft.network.chat.*;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import org.jetbrains.annotations.Nullable;
 
@@ -20,6 +21,11 @@ import static com.denisnumb.discord_chat_mod.chat_style.ChatStyleUtils.*;
 import static com.denisnumb.discord_chat_mod.chat_style.Parameters.*;
 
 public class MinecraftChatStyleProvider {
+    private static Map<String, Component> buildPositionComponentParameters(@Nullable Entity entity){
+        return buildPositionParameters(entity).entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> Component.literal(e.getValue())));
+    }
+
     private static Component applyStyleToAdvancement(String translatedTitle, String translatedDescription, Style advancementStyle) {
         Component title = Component.literal(translatedTitle);
         Component description = ComponentUtils.mergeStyles(title.copy(), Style.EMPTY.withColor(advancementStyle.getColor())).append("\n")
@@ -48,9 +54,10 @@ public class MinecraftChatStyleProvider {
         MutableComponent template = parseConfigTemplateMarkdown(setConfigTemplateTranslatableParameters(messageStringTemplate, translationKey));
         Style advancementStyle = parseTemplateParameterStyles(template, ADVANCEMENT).get(ADVANCEMENT);
 
-        return Optional.of(applyParametersToTemplate(template,
-                Map.of(PLAYER, player.getDisplayName(), ADVANCEMENT, applyStyleToAdvancement(title, description, advancementStyle))
-        ));
+        return Optional.of(applyParametersToTemplate(template, mergeMaps(
+                Map.of(PLAYER, player.getDisplayName(), ADVANCEMENT, applyStyleToAdvancement(title, description, advancementStyle)),
+                buildPositionComponentParameters(player)
+        )));
     }
 
     public static Optional<Component> getStyledJoinedLeftMessage(Player player, boolean isJoin) {
@@ -66,11 +73,11 @@ public class MinecraftChatStyleProvider {
 
         return Optional.of(applyParametersToTemplate(
                 parseConfigTemplateMarkdown(setConfigTemplateTranslatableParameters(messageStringTemplate, translationKey)),
-                Map.of(PLAYER, player.getDisplayName())
+                mergeMaps(Map.of(PLAYER, player.getDisplayName()), buildPositionComponentParameters(player))
         ));
     }
 
-    public record ChatMessageComponents(Component player, Component content, @Nullable Component team) {}
+    public record ChatMessageComponents(Component player, Component content, @Nullable Component team, @Nullable Entity sender) {}
 
     public static Optional<Component> getStyledChatMessage(ResourceKey<ChatType> chatType, ChatMessageComponents components){
         String configTemplate = getConfigTemplateByChatType(chatType);
@@ -87,10 +94,13 @@ public class MinecraftChatStyleProvider {
                 .boxed()
                 .collect(Collectors.toMap(i -> params[i], i -> values[i]));
 
-        return Optional.of(applyParametersToTemplate(parseConfigTemplateMarkdown(configTemplate), parameterToComponent));
+        return Optional.of(applyParametersToTemplate(
+                parseConfigTemplateMarkdown(configTemplate),
+                mergeMaps(parameterToComponent, buildPositionComponentParameters(components.sender()))
+        ));
     }
 
-    public static Optional<Component> getStyledDeathMessage(DeathMessageComponents components) {
+    public static Optional<Component> getStyledDeathMessage(DeathMessageComponents components, Entity entity) {
         IConfigProvider config = ConfigProvider.getConfig();
 
         String causeStyle = config.minecraftPlayerDeathCauseStyle().replace(DEATH_CAUSE, DEATH_CAUSE_REPLACEMENT_TAG);
@@ -114,6 +124,7 @@ public class MinecraftChatStyleProvider {
         parameterToDeathMessageComponent.put(DIED_ENTITY_REPLACEMENT_TAG, playerTemplate);
         parameterToDeathMessageComponent.put(KILLER_ENTITY_REPLACEMENT_TAG, components.killerEntity() != null ? entityTemplate : null);
         parameterToDeathMessageComponent.put(ITEM_REPLACEMENT_TAG, components.item() != null ? itemTemplate : null);
+        parameterToDeathMessageComponent.putAll(buildPositionComponentParameters(entity));
 
         return Optional.of(applyParametersToTemplate(causeTemplate.copy(), parameterToDeathMessageComponent));
     }

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/chat_style/Parameters.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/chat_style/Parameters.java
@@ -11,6 +11,10 @@ public class Parameters {
     public static final String MEMBER = "{member}";
     public static final String USER = "{user}";
     public static final String PLAYER_AVATAR_URL = "{player_avatar_url}";
+    public static final String X = "{x}";
+    public static final String Y = "{y}";
+    public static final String Z = "{z}";
+    public static final String DIMENSION = "{dimension}";
     public static final String PLAYER_JOINED = "multiplayer.player.joined";
     public static final String PLAYER_LEFT = "multiplayer.player.left";
     public static final String DEATH_CAUSE = "{death_cause}";

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/commands/vanilla/EmoteCommand.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/commands/vanilla/EmoteCommand.java
@@ -50,7 +50,7 @@ public class EmoteCommand {
 
                 MinecraftEvents.handleChatMessage(
                         CustomChatTypeRegistry.EMOTE_COMMAND,
-                        new MinecraftChatStyleProvider.ChatMessageComponents(senderComponent, messageContent, null)
+                        new MinecraftChatStyleProvider.ChatMessageComponents(senderComponent, messageContent, null, source.getEntity())
                 ).ifPresentOrElse(
                         styledContent -> {
                             ChatType.Bound styledBound = buildBound(CustomChatTypeRegistry.EMOTE_COMMAND, source.registryAccess(), senderComponent, messageContent);

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/commands/vanilla/MsgCommand.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/commands/vanilla/MsgCommand.java
@@ -61,7 +61,7 @@ public class MsgCommand {
 
         MinecraftEvents.handleChatMessage(
                 CustomChatTypeRegistry.MSG_COMMAND_INCOMING,
-                new MinecraftChatStyleProvider.ChatMessageComponents(commandSourceStack.getDisplayName(), playerChatMessageStyled.decoratedContent(), null)
+                new MinecraftChatStyleProvider.ChatMessageComponents(commandSourceStack.getDisplayName(), playerChatMessageStyled.decoratedContent(), null, commandSourceStack.getEntity())
         ).ifPresentOrElse(
                 styledContent -> sendMessageStyled(commandSourceStack, collection, playerChatMessageStyled, styledContent),
                 () -> sendMessageDefault(commandSourceStack, collection, playerChatMessageStyled)
@@ -81,7 +81,7 @@ public class MsgCommand {
         for (ServerPlayer serverPlayer : collection) {
             Optional<Component> styledOutgoingContentOptional = MinecraftEvents.handleChatMessage(
                     CustomChatTypeRegistry.MSG_COMMAND_OUTGOING,
-                    new MinecraftChatStyleProvider.ChatMessageComponents(serverPlayer.getDisplayName(), playerChatMessage.decoratedContent(), null)
+                    new MinecraftChatStyleProvider.ChatMessageComponents(serverPlayer.getDisplayName(), playerChatMessage.decoratedContent(), null, commandSourceStack.getEntity())
             );
 
             if (styledOutgoingContentOptional.isPresent()){

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/commands/vanilla/SayCommand.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/commands/vanilla/SayCommand.java
@@ -46,7 +46,7 @@ public class SayCommand {
 
                                         MinecraftEvents.handleChatMessage(
                                                 CustomChatTypeRegistry.SAY_COMMAND,
-                                                new MinecraftChatStyleProvider.ChatMessageComponents(senderComponent, messageContent, null)
+                                                new MinecraftChatStyleProvider.ChatMessageComponents(senderComponent, messageContent, null, source.getEntity())
                                         ).ifPresentOrElse(
                                                 styledContent -> {
                                                     ChatType.Bound styledBound = buildBound(CustomChatTypeRegistry.SAY_COMMAND, source.registryAccess(), senderComponent, messageContent);

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/commands/vanilla/TeamMsgCommand.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/commands/vanilla/TeamMsgCommand.java
@@ -56,7 +56,8 @@ public class TeamMsgCommand {
                 new MinecraftChatStyleProvider.ChatMessageComponents(
                         commandSourceStack.getDisplayName(),
                         playerChatMessageStyled.decoratedContent(),
-                        playerTeam.getFormattedDisplayName().withStyle(SUGGEST_STYLE)
+                        playerTeam.getFormattedDisplayName().withStyle(SUGGEST_STYLE),
+                        entity
                 )
         ).ifPresentOrElse(
                 styledContent -> sendMessageStyled(commandSourceStack, entity, playerTeam, list, playerChatMessageStyled, styledContent),
@@ -77,7 +78,8 @@ public class TeamMsgCommand {
                 new MinecraftChatStyleProvider.ChatMessageComponents(
                         commandSourceStack.getDisplayName(),
                         playerChatMessage.decoratedContent(),
-                        playerTeam.getFormattedDisplayName().withStyle(SUGGEST_STYLE)
+                        playerTeam.getFormattedDisplayName().withStyle(SUGGEST_STYLE),
+                        entity
                 )
         );
 

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigComments.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigComments.java
@@ -239,6 +239,8 @@ public class ConfigComments {
 
              {HH}, {MM}, {SS} — Hours, minutes, and seconds at the time the message was sent. Example usage: "[{HH}:{MM}] <{player}> {message}"\
 
+             {x}, {y}, {z}, {dimension} — the player's coordinates and dimension name\
+
              You can read more about this configuration section and see examples here: https://github.com/denisnumb/discord-chat-mod/wiki/Minecraft-Chat-Customization\
 
              [!] If enabled, make sure you don't have any other chat styling mods installed.\
@@ -390,6 +392,8 @@ public class ConfigComments {
              Global parameters available for all styles listed below:\
 
              {player_avatar_url} — link to the player's avatar (available wherever the {player} parameter is present)\
+
+             {x}, {y}, {z}, {dimension} — the player's coordinates and dimension name (available wherever the {player} parameter is present)\
 
              {timestamp} — current number of seconds in the system. It's convenient to substitute when using Discord timestamps, for example: <t:{timestamp}:R>\
 

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/discord/chat_style/DiscordChatStyleProvider.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/discord/chat_style/DiscordChatStyleProvider.java
@@ -123,7 +123,7 @@ public class DiscordChatStyleProvider {
         else
             result.put(PLAYER_AVATAR_URL, ConfigProvider.getConfig().webhookServerAvatarUrl());
 
-        return result;
+        return mergeMaps(result, buildPositionParameters(entity));
     }
 
     public static Optional<DiscordMessageComponents> getDiscordMessageComponents(MessageType messageType, Map<String, String> parameterMap){

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/mixin/chat_style/ServerGamePacketListenerImplMixin.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/mixin/chat_style/ServerGamePacketListenerImplMixin.java
@@ -84,7 +84,7 @@ public abstract class ServerGamePacketListenerImplMixin extends ServerCommonPack
 
         MinecraftEvents.handleChatMessage(
                 CustomChatTypeRegistry.CHAT,
-                new ChatMessageComponents(playerComponent, withMarkdown, null)
+                new ChatMessageComponents(playerComponent, withMarkdown, null, player)
         ).ifPresent(styledContent -> {
             ChatType.Bound styledBound = buildBound(CustomChatTypeRegistry.CHAT, player.level().registryAccess(), playerComponent, withMarkdown);
             args.set(0, originalMessage.withUnsignedContent(styledContent));


### PR DESCRIPTION
Fixes #54.

Adds global `{x}`, `{y}`, `{z}`, and `{dimension}` parameters, usable wherever `{player}` is available (chat, join/leave, death, advancements, command styles) on both the Discord and Minecraft message templates. `{dimension}` is "Overworld", "Nether", or "End" for vanilla dimensions; modded dimensions use a prettified path (e.g. `the_aether` becomes "The Aether"), which is the one spot worth a second opinion if you would prefer the raw id instead.

Tested on a 1.21.1 dev server: coordinates and dimension render correctly in chat, join, death, and advancement messages on both the Minecraft and Discord sides, across the Overworld, Nether, and End. Build verified on all six version branches.