### PR TITLE
feat: respect styled nicknames and custom skins in webhooks 1.21.11

### DIFF
--- a/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigComments.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/config/ConfigComments.java
@@ -151,13 +151,15 @@ public class ConfigComments {
     public static final String WEBHOOK_PLAYER_AVATAR_URL_COMMENT
             = String.format("""
              Url to get the player's display avatar\
-            
-             You can specify a link with dynamic parameters <uuid> and <name>, which will be automatically substituted when requesting an image\
-            
-             <uuid> — player's UUID\
-            
-             <name> — player's nickname\
-            
+
+             You can specify a link with dynamic parameters <uuid>, <name> and <texture>, which will be automatically substituted when requesting an image\
+
+             <uuid> - player's UUID\
+
+             <name> - player's nickname\
+
+             <texture> - texture hash from the player's GameProfile (works with skin mods like Fabric Tailor or SkinRestorer that write into the server-side profile). Example: https://mc-heads.net/avatar/<texture>\
+
              Default: %s\
             """, WEBHOOK_PLAYER_AVATAR_URL_DEFAULT);
 

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/discord/utils/DiscordMessageUtils.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/discord/utils/DiscordMessageUtils.java
@@ -107,7 +107,7 @@ public class DiscordMessageUtils {
 
                 return sendWebhookWithImage(
                         optionalWebhook.get().getUrl(),
-                        payload.setUsername(player.getName().getString())
+                        payload.setUsername(player.getDisplayName().getString())
                                 .setAvatarUrl(getPlayerAvatarUrl(player)),
                         new WebhookAttachment(imageData.data(), imageData.fileName())
                 ).get();
@@ -224,7 +224,7 @@ public class DiscordMessageUtils {
                 : new WebhookPayload(components.getEmbed());
 
         payload.setUsername(player != null
-                ? player.getName().getString()
+                ? player.getDisplayName().getString()
                 : getWebhookServerName()
         );
 

--- a/common/src/main/java/com/denisnumb/discord_chat_mod/discord/utils/WebhookUtils.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/discord/utils/WebhookUtils.java
@@ -8,6 +8,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.annotations.SerializedName;
+import com.mojang.authlib.properties.Property;
 import com.mojang.logging.LogUtils;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.minecraft.world.entity.player.Player;
@@ -20,6 +21,8 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -228,12 +231,45 @@ public class WebhookUtils {
                 avatarUrlTemplate = avatarUrlTemplate.replace("<uuid>", optionalUUID.get());
         }
 
+        if (avatarUrlTemplate.contains("<texture>")){
+            Optional<String> optionalTexture = getPlayerTextureHash(player);
+            if (optionalTexture.isPresent())
+                avatarUrlTemplate = avatarUrlTemplate.replace("<texture>", optionalTexture.get());
+        }
+
         if (isImageUrl(getMimeType(avatarUrlTemplate)))
             return avatarUrlTemplate;
 
         return isImageUrl(getMimeType(defaultAvatarUrl))
                 ? defaultAvatarUrl
                 : "https://mc-heads.net/avatar/steve_head_png";
+    }
+
+    public static Optional<String> getPlayerTextureHash(Player player) {
+        try {
+            Collection<Property> textures = player.getGameProfile().properties().get("textures");
+            if (textures.isEmpty())
+                return Optional.empty();
+
+            String encoded = textures.iterator().next().value();
+            String decoded = new String(Base64.getDecoder().decode(encoded), StandardCharsets.UTF_8);
+            JsonObject json = JsonParser.parseString(decoded).getAsJsonObject();
+            if (!json.has("textures"))
+                return Optional.empty();
+
+            JsonObject texturesObject = json.getAsJsonObject("textures");
+            if (!texturesObject.has("SKIN"))
+                return Optional.empty();
+
+            String skinUrl = texturesObject.getAsJsonObject("SKIN").get("url").getAsString();
+            int slashIndex = skinUrl.lastIndexOf('/');
+            if (slashIndex < 0 || slashIndex == skinUrl.length() - 1)
+                return Optional.empty();
+
+            return Optional.of(skinUrl.substring(slashIndex + 1));
+        } catch (Exception ignored) {}
+
+        return Optional.empty();
     }
 
     public static Optional<String> getUUIDFromMojangAPI(String username) {


### PR DESCRIPTION
Fixes #68.

Webhook mode uses player.getName() for the webhook username, which always
shows the account name, and resolves player avatars by UUID through Mojang's
session servers, so skins set by Fabric Tailor or SkinRestorer never appear.
Both behaviors are inconsistent with the rest of the mod, which already uses
display names.

setUsername() now reads getDisplayName().getString(), which picks up styled
names from Styled Nicknames, Drogstyle, and other mods that override the
display component. webhookPlayerAvatarUrl gains a <texture> placeholder that
resolves to the texture hash from the player's server-side GameProfile, so
any mod that writes the standard textures property is supported with no soft
dependency. Existing UUID and name templates keep working; when no texture
is available the URL stays literal and falls back through the existing mime
check to webhookPlayerDefaultAvatarUrl.

Tested on a 1.21.1 fabric dev server (the change is functionally identical
across version branches, only authlib accessor names differ): Styled
Nicknames appear as the webhook username with formatting codes stripped,
Fabric Tailor skins render as the webhook avatar with
https://mc-heads.net/avatar/<texture>, and offline players with no texture
fall back to webhookPlayerDefaultAvatarUrl. /set_avatar_url still overrides
as expected.

Port of #158 to the 1.21.11 branch.