### PR TITLE
fix: skip server start message for integrated server 1.20.1

### DIFF
--- a/common/src/main/java/com/denisnumb/discord_chat_mod/DiscordChatMod.java
+++ b/common/src/main/java/com/denisnumb/discord_chat_mod/DiscordChatMod.java
@@ -67,6 +67,8 @@ public final class DiscordChatMod {
 
     public static void onServerStarted() {
         ServerLogsRetranslator.start();
+        if (server == null || !server.isDedicatedServer())
+            return;
         serverStartPending.set(true);
         trySendServerStartMessage();
     }


### PR DESCRIPTION
Fixes #92.

The deferred-send change from #142 set `serverStartPending` in `onServerStarted` regardless of server type. For singleplayer the flag stayed true until the player clicked Open To LAN, at which point `onIntegratedServerStarted` ran `initJDA` and the deferred `trySendServerStartMessage` fired the regular SERVER_START embed in addition to the LOCAL_SERVER_START one.

Gating the flag-set and send on `server.isDedicatedServer()`. Integrated servers send LOCAL_SERVER_START from `onIntegratedServerStarted` only, so the flag-based path is unnecessary there and was the source of the double-send.

Verified on a 1.21.1 fabric dev client and a 1.21.1 neoforge dev client across the three relevant scenarios: dedicated server still sends SERVER_START once, SP without LAN sends nothing, SP then Open To LAN now sends only LOCAL_SERVER_START. Same two-line diff applies cleanly to every version branch; all six compile.

Sorry I didn't catch this in the original #142, that's on me.

Port of #165 to the 1.20.1 branch.